### PR TITLE
Remove bogus "30px" at the end of #logo rule

### DIFF
--- a/html/lesson2/tutorial.md
+++ b/html/lesson2/tutorial.md
@@ -153,7 +153,7 @@ Selects the element with the id logo.
 
 ```css
 #logo {
-   margin: 0 auto 30px 30px;
+   margin: 0 auto 30px;
    width: 200px;
 }
 ```


### PR DESCRIPTION
Or else the logo won't be centred.
