### PR TITLE
Change equality section to use === rather than ==

### DIFF
--- a/js/lesson1/tutorial.md
+++ b/js/lesson1/tutorial.md
@@ -193,23 +193,23 @@ if (!codebarIsAwesome) {
 
 Conditions work with a number of evaluated statements. Some of the comparisons we can use are
 
-#### Equality `==`
+#### Equality `===`
 
 ```js
 var apples = "apples";
 var oranges = "oranges";
 
-if (apples == oranges) {
+if (apples === oranges) {
   console.log("Apples and Oranges are the same thing!");
 }
 ```
 
 This should not output anything, **apples** and **oranges** are not the same thing!
 
-#### Inequality `!=`
+#### Inequality `!==`
 
 ```js
-if (apples != oranges) {
+if (apples !== oranges) {
   console.log("Apples are not Oranges!");
 }
 ```


### PR DESCRIPTION
The == and != operators are known as the "evil twins" to the === and !== operators as they don't always behave as expected. It is recommended that === and !== are always used for equality comparisons.

See JavaScript: The Good Parts by Douglas Crockford.
