### PR TITLE
Changed processEpisode item_html variable to be local rather than global

### DIFF
--- a/js/lesson4/tutorial.md
+++ b/js/lesson4/tutorial.md
@@ -326,7 +326,7 @@ Also, to make your code easier to read, try constructing the html in a method th
 
 ```javascript
 function processEpisode(episode) {
- item_html = "<li>"
+ var item_html = "<li>"
  item_html += "<h2>" + episode.programme.display_titles.title + "</h2>";
  // display image
  // display date and time


### PR DESCRIPTION
This line in tutorial.md, and the script.js file in the tutorial's associated gist, define function variables as global rather than local.

I've cloned the gist, and made (and tested) the relevant changes to script.js, which can be seen here:
https://gist.github.com/jkbits1/e8a0d2bacc2c89b6a7ff/revisions

By all means reject this request, e.g. if the students should know and spot sort of thing by now, or if the coach and student will consider this together, etc. 

These changes also make variable values much clearer when stepping through the code in the browser debugger.
