### PR TITLE
Add explicit instructions for where to get images

### DIFF
--- a/html/lesson1/tutorial.md
+++ b/html/lesson1/tutorial.md
@@ -220,7 +220,18 @@ So far we've learned a lot about how to add text to our page. But how about some
 
 Let's add some images!
 
-Image are primarily made up of three attributes
+Before we start, we'll need to add the image files we want to use to the project folder.  It's a good idea to keep images in their own folder, so first, create a folder called 'images' inside the same folder as your HTML file.  Next, download the images you'll need by right clicking on the following links, selecting 'Save Link As...', and saving to the images folder you just created:
+
+* [logo.png](/tutorials/html/lesson1/images/logo.png "logo.png")
+* [img1.jpg](/tutorials/html/lesson1/images/img1.jpg "img1.jpg")
+* [img2.jpg](/tutorials/html/lesson2/images/img2.jpg "img2.jpg")
+* [img3.jpg](/tutorials/html/lesson3/images/img3.jpg "img3.jpg")
+* [img4.jpg](/tutorials/html/lesson4/images/img4.jpg "img4.jpg")
+* [img5.jpg](/tutorials/html/lesson5/images/img5.jpg "img5.jpg")
+* [img6.jpg](/tutorials/html/lesson6/images/img6.jpg "img6.jpg")
+
+Images are primarily made up of three attributes
+
 * the `<img>` tag
 * the `src` attribute, which lets the page know what image we want to view
 * the `alt` attribute, where we describe our image


### PR DESCRIPTION
In lesson 1, I'm not sure it's clear where to get the image files from.
This commit gives the student instuctions for downloading the images and
adding them to an /images folder.  It also makes sure the images
attributes are rendered in a list (before they weren't as the markdown
was missing a line before the list).
