### PR TITLE
Typo - use strict equality in code snippet.

### DIFF
--- a/js/lesson1/tutorial.md
+++ b/js/lesson1/tutorial.md
@@ -217,7 +217,7 @@ Conditions work with a number of evaluated statements. Some of the comparisons w
 var apples = "apples";
 var oranges = "oranges";
 
-if (apples == oranges) {
+if (apples === oranges) {
   console.log("Apples and Oranges are the same thing!");
 }
 ```


### PR DESCRIPTION
The text describes strict equality whereas the code describes '=='
