### PR TITLE
Use h2 instead of strong

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
 
         <p>If you're new to Codebar, take a look at our <a href="general/setup/tutorial.html">getting started guide</a> to set up your computer for our tutorials.</p>
 
-          <strong>HTML</strong>
+          <h2>HTML</h2>
           <ul>
             <li><a href="html/lesson1/tutorial.html">Lesson 1 - Introducing HTML</a></li>
             <li><a href="html/lesson2/tutorial.html">Lesson 2 - Introducing CSS</a></li>
@@ -36,13 +36,13 @@
             <li><a href="html/lesson6/tutorial.html">Lesson 6 - Advanced HTML5</a></li>
           </ul>
 
-          <strong>Version Control</strong>
+          <h2>Version Control</h2>
           <ul>
             <li><a href="version-control/introduction/tutorial.html">Introduction to version control</a></li>
             <li><a href="version-control/command-line/tutorial.html">Introduction to the git command line</a></li>
           </ul>
 
-          <strong>JavaScript</strong>
+          <h2>JavaScript</h2>
           <ul>
             <li><a href="js/lesson1/tutorial.html">Introduction to JavaScript</a></li>
             <li><a href="js/lesson2/tutorial.html">Beginning JavaScript</a></li>
@@ -54,7 +54,7 @@
             <li><a href="js/lesson8/tutorial.html">Building your own app</a></li>
           </ul>
 
-          <strong>Ruby</strong>
+          <h2>Ruby</h2>
 
           <p class="lead">If you are just getting started with Ruby, we recommend using <a href="http://nitrous.io">nitrous.io</a>, as setting up your local environment can be time consuming.</p>
 


### PR DESCRIPTION
I think the `<strong>` "headlines" should actually be `<h2>` to give the document a more semantic structure.
