### PR TITLE
Update tutorial.md

### DIFF
--- a/js/lesson3/tutorial.md
+++ b/js/lesson3/tutorial.md
@@ -221,6 +221,8 @@ When we click on the Pending label, we want to set items to complete. We will do
 
 > Use `$(this)` to access the element that the event was triggered from.
 
+Try this in the console:
+
 First of all, bind a **click** event to the span we've added using its class with the `on()` function. As `<li>` is the parent node of the <span> element, we can access it using `parent()` (which is equivalent to `parentNode`
 that we've used in the previous lesson).
 


### PR DESCRIPTION
Not clear to students whether this should be attempted in the console or in the text editor - trying to explain why you can't bind event listeners to elements that don't exist on page load (and how to get around that) is maybe a bit complicated at this stage