### PR TITLE
adding correct link to first python tutorial

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
           <h2>Python</h2>
 
           <ul>
-            <li><a href="ruby/lesson1/tutorial.html">Introduction to Python</a></li>
+            <li><a href="python/lesson1/tutorial.html">Introduction to Python</a></li>
           </ul>
           </section>
           <footer>


### PR DESCRIPTION
now pointing to python tutorial 1 as opposed to ruby tutorial 1