### PR TITLE
Fixed link to python page

### DIFF
--- a/python/lesson1/tutorial.md
+++ b/python/lesson1/tutorial.md
@@ -1,3 +1,8 @@
+---
+layout: page
+title: Introduction to Python
+---
+
 #Introduction to Python
 
 There is a very good introduction article in [Google Developers Guide](https://developers.google.com/edu/python/introduction)


### PR DESCRIPTION
I noticed the link to the python tutorial was broken. Upon investigation I found the python markdown file was missing the frontmatter, resulting in an invalid page. I've added the relevant frontmatter, and the link now works.