### PR TITLE
Link to Slack instead of Gitter

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,11 @@
         <p class="view"><a href="https://github.com/codebar/tutorials">View on GitHub <small>codebar/tutorials</small></a></p>
       </header>
       <section>
-        <p class="lead">Are you working on the tutorials in your own time? Need some help? <a href="https://gitter.im/codebar/tutorials">Join the conversation on gitter!</a></p>
+        <p class="lead">
+          Are you working on the tutorials on your own time?
+          <a href="https://codebar-slack.herokuapp.com/" target="_blank">Join the codebar community on Slack</a>
+          to get help and discuss anything with students or coaches!
+        </p>
 
         <p>If you're new to codebar, take a look at our <a href="general/setup/tutorial.html">getting started guide</a> to set up your computer for our tutorials.</p>
 


### PR DESCRIPTION
The link to the Slack invite request form opens in a new window