### PR TITLE
Minor formatting change in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-View the tutorials [here](http://codebar.github.io/tutorials)
+This is the source code for <http://tutorials.codebar.io>
 
 ## Getting started
 
 This is a [GitHub Pages](https://pages.github.com/) repo, so you can render the pages with [Jekyll](http://jekyllrb.com/):
+
 1. `gem install jekyll` (`sudo` if needed)
 2. `jekyll serve`
 3. go to http://127.0.0.1:4000
@@ -13,4 +14,4 @@ We encourage you to contribute with your suggestions and corrections, head to ou
 
 ## License
 
-Codebar Tutorials are released under the [Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)](http://creativecommons.org/licenses/by-nc-sa/4.0/). 
+Codebar Tutorials are released under the [Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)](http://creativecommons.org/licenses/by-nc-sa/4.0/).


### PR DESCRIPTION
- Make the `<ol>` in the `Contributing` section actually display as a list rather than in one line. 
- Point to the tutorials' public URL in the first paragraph of the README