### PR TITLE
Turn on syntax highlighting of code blocks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 safe: true
 lsi: false
-highlighter: true
+highlighter: pygments
 future: true
 markdown: redcarpet
 encoding: utf-8


### PR DESCRIPTION
A picture says more than a thousand words:

![before_and_after](https://cloud.githubusercontent.com/assets/1446237/9514389/9e72959e-4c91-11e5-815b-9d1650b00152.png)
