### PR TITLE
Includes url to Slack channel and amends domains

### DIFF
--- a/index.pt.html
+++ b/index.pt.html
@@ -22,7 +22,7 @@
         <p class="view"><a href="https://github.com/codebar/tutorials">View on GitHub <small>codebar/tutorials</small></a></p>
       </header>
       <section>
-        <p class="lead">Você está estudando os tutoriais sozinho? Precisa de ajuda? <a href="https://gitter.im/codebar/tutorials">Junte-se a nós no gitter!</a></p>
+        <p class="lead">Você está estudando os tutoriais sozinho? Precisa de ajuda? Junte-se a nós no <a href="https://gitter.im/codebar/tutorials">gitter.im</a> ou <a href="https://codebar.slack.com/">Slack.com</a>!</p>
 
         <p>Se você é novo no Codebar, dê uma olhada no <a href="general/setup/tutorial.pt.html">guia para iniciantes</a>, que ajuda a preparar o seu computador para nossos tutoriais.</p>
 

--- a/index.pt.html
+++ b/index.pt.html
@@ -22,7 +22,7 @@
         <p class="view"><a href="https://github.com/codebar/tutorials">View on GitHub <small>codebar/tutorials</small></a></p>
       </header>
       <section>
-        <p class="lead">Você está estudando os tutoriais sozinho? Precisa de ajuda? Junte-se a nós no <a href="https://gitter.im/codebar/tutorials">gitter.im</a> ou <a href="https://codebar.slack.com/">Slack.com</a>!</p>
+        <p class="lead">Você está estudando os tutoriais sozinho? Precisa de ajuda? Junte-se a nós no <a href="https://codebar.slack.com/">Slack.com</a>!</p>
 
         <p>Se você é novo no Codebar, dê uma olhada no <a href="general/setup/tutorial.pt.html">guia para iniciantes</a>, que ajuda a preparar o seu computador para nossos tutoriais.</p>
 

--- a/js/lesson8/tutorial.md
+++ b/js/lesson8/tutorial.md
@@ -9,7 +9,7 @@ Ask your coach for help on getting your project setup in Github and granting per
 
 Today's session is not aimed to teach you anything new programming-wise but to enable you to start building things on your own. You are not expected to produce a working application by the end of today's lesson but to structure your thoughts and figure out what you want to build.
 
-To get help outside our sessions, join the codebar channel on [gitter.im](https://gitter.im/codebar) or [slack.com](https://codebar.slack.com/) or send an email to [hello at codebar.io](mailto://hello@codebar.io).
+To get help outside our sessions, join the codebar channel on [slack.com](https://codebar.slack.com/) or send an email to [hello at codebar.io](mailto://hello@codebar.io).
 
 # Things to help you get started
 

--- a/js/lesson8/tutorial.md
+++ b/js/lesson8/tutorial.md
@@ -9,7 +9,7 @@ Ask your coach for help on getting your project setup in Github and granting per
 
 Today's session is not aimed to teach you anything new programming-wise but to enable you to start building things on your own. You are not expected to produce a working application by the end of today's lesson but to structure your thoughts and figure out what you want to build.
 
-To get help outside our sessions, [join the codebar channel](https://gitter.im/codebar) or send an email to [hello at codebar.io](mailto://hello@codebar.io).
+To get help outside our sessions, join the codebar channel on [gitter.im](https://gitter.im/codebar) or [slack.com](https://codebar.slack.com/) or send an email to [hello at codebar.io](mailto://hello@codebar.io).
 
 # Things to help you get started
 
@@ -93,4 +93,3 @@ Some popular API's that you may find useful
 
 ---
 This ends our **Building your own app** tutorial. Is there something you don't understand? Try and go through the provided resources with your coach. If you have any feedback, or can think of ways to improve this tutorial [send us an email](mailto:feedback@codebar.io) and let us know.
-

--- a/ruby/lesson2/tutorial.md
+++ b/ruby/lesson2/tutorial.md
@@ -245,7 +245,7 @@ rake regen
 
 To try out the koans run `rake`. It gives you a hint as to what fails and you can move forward by fixing the file and running `rake` again.
 
-If you are working through this at home you can ask for help in our [gitter channel](https://gitter.im/codebar/tutorials).
+If you are working through this at home you can ask for help in our [gitter.im channel](https://gitter.im/codebar/tutorials) or [slack.com channel](https://codebar.slack.com/messages/tutorials/).
 
 ##Some reading material
 

--- a/ruby/lesson2/tutorial.md
+++ b/ruby/lesson2/tutorial.md
@@ -245,7 +245,7 @@ rake regen
 
 To try out the koans run `rake`. It gives you a hint as to what fails and you can move forward by fixing the file and running `rake` again.
 
-If you are working through this at home you can ask for help in our [gitter.im channel](https://gitter.im/codebar/tutorials) or [slack.com channel](https://codebar.slack.com/messages/tutorials/).
+If you are working through this at home you can ask for help in our [slack.com channel](https://codebar.slack.com/messages/tutorials/).
 
 ##Some reading material
 

--- a/ruby/lesson4/tutorial.md
+++ b/ruby/lesson4/tutorial.md
@@ -9,7 +9,7 @@ There are no sample files for this tutorial as you should already know how to cr
 
 Don't forget to commit to git regularly and also try to **type** out the examples as much as possible instead of copy &amp; pasting!
 
-If you are going through the tutorial in your own time and need any help then [join the chatroom](https://gitter.im/codebar/tutorials), but first read our [Code of Conduct](http://codebar.io/code-of-conduct) as we will not tolerate any inappropriate behavior.
+If you are going through the tutorial in your own time and need any help then join the [gitter.im chatroom](https://gitter.im/codebar/tutorials) or the [slack.com channel](https://codebar.slack.com/messages/tutorials/), but first read our [Code of Conduct](http://codebar.io/code-of-conduct) as we will not tolerate any inappropriate behavior.
 
 # What is Object Oriented Programming?
 

--- a/ruby/lesson4/tutorial.md
+++ b/ruby/lesson4/tutorial.md
@@ -9,7 +9,7 @@ There are no sample files for this tutorial as you should already know how to cr
 
 Don't forget to commit to git regularly and also try to **type** out the examples as much as possible instead of copy &amp; pasting!
 
-If you are going through the tutorial in your own time and need any help then join the [gitter.im chatroom](https://gitter.im/codebar/tutorials) or the [slack.com channel](https://codebar.slack.com/messages/tutorials/), but first read our [Code of Conduct](http://codebar.io/code-of-conduct) as we will not tolerate any inappropriate behavior.
+If you are going through the tutorial in your own time and need any help then join the [slack.com channel](https://codebar.slack.com/messages/tutorials/), but first read our [Code of Conduct](http://codebar.io/code-of-conduct) as we will not tolerate any inappropriate behavior.
 
 # What is Object Oriented Programming?
 

--- a/ruby/lesson5/tutorial.md
+++ b/ruby/lesson5/tutorial.md
@@ -7,7 +7,7 @@ In today's tutorial, we will be again going through OO concepts - some of which 
 
 Don't forget to commit to git regularly and also try to **type** out the examples as much as possible instead of copy &amp; pasting!
 
-If you are going through the tutorial in your own time and need any help then [join the chatroom](https://gitter.im/codebar/tutorials), but first read our [Code of Conduct](http://codebar.io/code-of-conduct) as we will not tolerate any inappropriate behavior.
+If you are going through the tutorial in your own time and need any help then join the [gitter.im chatroom](https://gitter.im/codebar/tutorials) or the [slack.com channel](https://codebar.slack.com/messages/tutorials/), but first read our [Code of Conduct](http://codebar.io/code-of-conduct) as we will not tolerate any inappropriate behavior.
 
 # How does inheritance fit in OO?
 
@@ -281,13 +281,11 @@ Extend the game so that
 2. add an `inventory` method to a `Player`. Calling `inventory` prints out a list with all the items that the `Player` is holding
 3. extract a `Location` object. Modify your code so that it works with the location object, instead of a hash.
 
-If you need any help don't hesitate to ask [in our chatroom](https://gitter.im/codebar/tutorials).
+If you need any help don't hesitate to ask in our [gitter.im  chatroom](https://gitter.im/codebar/tutorials) or [slack.com channel](https://codebar.slack.com/messages/tutorials/).
 
 ---
 This ends our **Object Oriented Ruby and Inheritance (part 2)** tutorial. Is there something you don't understand? Try and go through the provided resources with your coach. If you have any feedback, or can think of ways to improve this tutorial [send us an email](mailto:feedback@codebar.io) and let us know.
 
-### Further reading 
+### Further reading
 
-If you want to challenge yourself further and dive into the world of Rails, a Ruby framework for building websites, here is a tutorial book to [get you started.](https://www.railstutorial.org/book/frontmatter) 
-
-
+If you want to challenge yourself further and dive into the world of Rails, a Ruby framework for building websites, here is a tutorial book to [get you started.](https://www.railstutorial.org/book/frontmatter)

--- a/ruby/lesson5/tutorial.md
+++ b/ruby/lesson5/tutorial.md
@@ -7,7 +7,7 @@ In today's tutorial, we will be again going through OO concepts - some of which 
 
 Don't forget to commit to git regularly and also try to **type** out the examples as much as possible instead of copy &amp; pasting!
 
-If you are going through the tutorial in your own time and need any help then join the [gitter.im chatroom](https://gitter.im/codebar/tutorials) or the [slack.com channel](https://codebar.slack.com/messages/tutorials/), but first read our [Code of Conduct](http://codebar.io/code-of-conduct) as we will not tolerate any inappropriate behavior.
+If you are going through the tutorial in your own time and need any help then join the [slack.com channel](https://codebar.slack.com/messages/tutorials/), but first read our [Code of Conduct](http://codebar.io/code-of-conduct) as we will not tolerate any inappropriate behavior.
 
 # How does inheritance fit in OO?
 


### PR DESCRIPTION
Increases clarity of domain names for chat rooms (gitter.im and slack.com – at time of writing).