### PR TITLE
fixed incorrect tutorials link

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -11,7 +11,7 @@ layout: default
     {% endif %}
     {{ content }}
     <footer>
-        <a href='http://codebar.github.io/tutorials/'>Back to tutorials</a>
+        <a href='http://tutorials.codebar.io/'>Back to tutorials</a>
         <a href='http://codebar.io/'>Codebar mainpage</a>
     </footer>
   </article>


### PR DESCRIPTION
when students followed the gh-pages link, some relative urls were breaking (img downloads etc)