### PR TITLE
HMTL Lesson 5 - updated 'required files' archive

### DIFF
--- a/html/lesson5/tutorial.md
+++ b/html/lesson5/tutorial.md
@@ -20,7 +20,7 @@ The page we will build will look similar to this [example page](http://codebar.g
 ### Required files
 
 
-Download the files required to begin working through the tutorial from [here](https://gist.github.com/despo/7565600/download)
+Download the files required to begin working through the tutorial from [here](https://drive.google.com/file/d/0Bws_MKyXHfv9VUYxazUzOE9Rc2M/view?usp=sharing)
 
 ## Getting started
 
@@ -436,5 +436,3 @@ You can find both the rgb and hex values of a color through [http://0to255.com](
 
 -----
 This ends our fifth lesson. How did you find the introduction to CSS3? Is there something you don't understand? Try and go through the provided resources with your coach. If you have any feedback, or can think of ways to improve this tutorial [send us an email](mailto:feedback@codebar.io) and let us know.
-
-


### PR DESCRIPTION
The 'required files' for HTML Lesson 5 are found in a flat structure, consisting of the HTML, CSS and images all in the same level of folder hierarchy. The guide, however, assumes that the images are found two levels down in an images folder, as demonstrated below

```
Let's try this out.

First let's set two background images, the first positioned on the right and the second on the left.

background: url('assets/images/background-right.jpg') right top no-repeat,
            url('assets/images/background-left.jpg') left no-repeat;
```

Initially I was simply going to change ```assets/images/*.jpg``` to ```*.jpg```, but it seems this was a deliberate change, and within the repo you can find the folder structure as promised.

I suspect what happened is the tutorial was updated, and so was the repo, however the 'required files'  zip was not rebuilt and rehosted. It's stored as a gist, and then zipped via GitHub's kindess - which is fine but also makes it impossible to create a file/folder hierarchy.

Instead, I have created a new archive and rehosted said archive on google drive. Links pointing to the required files have been updated in the markdown document.
