### PR TITLE
Remove strong tags from section wherethey have not been introduced yet

### DIFF
--- a/html/lesson1/tutorial.md
+++ b/html/lesson1/tutorial.md
@@ -154,9 +154,8 @@ Wrap your existing paragraph and link in a div and add a new heading to it.
   <h1>Owls</h1>
   <p>
     Most birds of prey sport eyes on the sides of their heads,
-    but the stereoscopic nature of
-    the owl's forward-facing <strong>eyes permits the greater
-    sense of depth perception</strong> necessary for low-light hunting.
+    but the stereoscopic nature of the owl's forward-facing eyes permits the greater
+    sense of depth perception necessary for low-light hunting.
     <a href="http://en.wikipedia.org/wiki/Owl">More information about owls...</a>
   </p>
 </div>


### PR DESCRIPTION
This change removes the `<strong>` tag from the expected output. This tag is not introduced until later on in this lesson. The introduction at this point also means the the expected text does not match what the student has been asked to type, which may cause confusion.