### PR TITLE
changing markdown support from redcarpet to kramdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ safe: true
 lsi: false
 highlighter: pygments
 future: true
-markdown: redcarpet
+markdown: kramdown
 encoding: utf-8
-redcarpet:
+kramdown:
   extensions: ["no_intra_emphasis", "fenced_code_blocks", "autolink", "tables", "with_toc_data"]


### PR DESCRIPTION
Solves #265, per this blog post:

https://github.com/blog/2100-github-pages-now-faster-and-simpler-with-jekyll-3-0