### PR TITLE
Change exercise 2 gist download link to new version

### DIFF
--- a/js/lesson3/tutorial.md
+++ b/js/lesson3/tutorial.md
@@ -299,7 +299,7 @@ Before you start, close any windows you still have open from the last
 exercise. This one also has files called `index.html` and `script.js`,
 and you don't want to edit the wrong one by accident.
 
-[Download the files](https://gist.github.com/despo/ab21d29aa1ea8fbbbb0e/download) required to begin working through the example.
+[Download the files](https://gist.github.com/niffinity/4edf3c21f0107a1099cc237dc6c8d66b/download) required to begin working through the example.
 
 If you're using git, you can clone this repo instead, and move the
 files under your Github page folder, in a directory called


### PR DESCRIPTION
Change html code in exercise 2 to make `input` element self closing. This is because unnecessary closing tag was causing a bug in the jQuery.

I have changed the url for the gist as I was unable to edit the gist directly. Please feel free to edit despo's gist yourself instead if you prefer.