### PR TITLE
Fixing broken table in JS lesson 5

### DIFF
--- a/js/lesson5/tutorial.md
+++ b/js/lesson5/tutorial.md
@@ -42,7 +42,8 @@ $.ajax({
 [Download](https://gist.github.com/despo/c76a7bd0bef66713a9ac/download) the exercise files or clone them directly from Github `git clone https://gist.github.com/c76a7bd0bef66713a9ac.git`
 
 ### API
-| type | resource | parameters | description |
+
+| Type | Resource | Parameters | Description |
 | ---- | -------- | ---------- | ----------- |
 | **POST**  | `http://hangman-api.herokuapp.com/hangman` | - | Create a new game |
 | **PUT**  | `http://hangman-api.herokuapp.com/hangman` | `{ token: game token, letter: guess }` | Guess a letter |


### PR DESCRIPTION
As stated in the title, JS lesson 5 had a table that didn't render properly. Fixed now by adding space between header before table and table itself.