### PR TITLE
Fix the link to the jQuery tutorial files

### DIFF
--- a/js/lesson3/tutorial.md
+++ b/js/lesson3/tutorial.md
@@ -41,7 +41,7 @@ Using jQuery and JavaScript functions, we are going to build a small
 todo list.
 
 Download the files that you will need to work through the example
-[here](https://gist.github.com/despo/309f684b7a6e002aaf1f).
+[here](https://gist.github.com/despo/309f684b7a6e002aaf1f/download).
 
 Alternatively, if you've already learned how to use git and would like
 to use it here, you can clone this repo:


### PR DESCRIPTION
The link pointed to the gist page instead.
I made it point to the zip file directly.