### PR TITLE
Readme fixups

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,19 +31,29 @@ $ gulp
 
 Then go to http://localhost:4000/test/specrunner.html to run the tests. Tests should be green.
 
-> *Gulp is only used for development, not in production. In your local copy of this repo, it will concatenate and minify the files inside the `javascripts-dev` folder, as well as watch for changes in that folder. The concatenated and minified JS file will be generated inside the `javascripts` folder. You can push both folders when you are finished with your changes. GitHub pages will then  generate the site in production with whatever is inside the `javascripts` folder.*
+> *Gulp is only used for development, not in production. In your local copy of
+> this repo, it will concatenate and minify the files inside the
+> `javascripts-dev` folder, as well as watch for changes in that folder. The
+> concatenated and minified JS file will be generated inside the `javascripts`
+> folder. You can push both folders when you are finished with your changes.
+> GitHub pages will then  generate the site in production with whatever is
+> inside the `javascripts` folder.*
 
 If you are just updating or adding new tutorials, follow steps 1 to 3 only.
 
 ## Getting in Touch
 
-You can go to the general [codebar Slack channel here](https://codebar.slack.com/messages/general/) or the dedicated [tutorials channel here](https://codebar.slack.com/messages/tutorials/). Use it to get in touch and chat to other codebar students/coaches, or if you need help.
+You can go to the general [codebar Slack channel here](https://codebar.slack.com/messages/general/) or the
+dedicated [tutorials channel here](https://codebar.slack.com/messages/tutorials/). Use it to get in touch
+and chat to other codebar students/coaches, or if you need help.
 
 If you are not on Slack use [this link](http://codebar-slack.herokuapp.com/) to get an invite.
 
 ## Contributing
 
-We encourage you to contribute with your suggestions and corrections. Head to our [issues page](https://github.com/codebar/tutorials/issues) and open a new issue or help on the existing ones.
+We encourage you to contribute with your suggestions and corrections. Head to our
+[issues page](https://github.com/codebar/tutorials/issues) and open a new issue or
+help on the existing ones.
 
 
 ##### General tutorial rule
@@ -54,14 +64,23 @@ We encourage you to contribute with your suggestions and corrections. Head to ou
 	* Objectives - "In this tutorial we are going to look at..."
 	* Goals - "By the end of this tutorial you will have..."
 	* Then the exercises.
-	* Bonus - This is not always required but if you feel there is something that could be added then please include it.
-	* Further reading - Again this is not always required but if you feel there was something in the tutorials that could be covered in more depth then please include any good reading materials/videos or extra tutorials.
+        * Bonus - This is not always required but if you feel there is
+          something that could be added then please include it.
+        * Further reading - Again this is not always required but if you feel
+          there was something in the tutorials that could be covered in more
+          depth then please include any good reading materials/videos or extra
+          tutorials.
 
-3. Repetition is good. A tutorial can contain multiple exercises that ask the students to take similar steps (e.g. for HTTP Requests one exercise introduces GET, another has GET and POST etc).
+3. Repetition is good. A tutorial can contain multiple exercises that ask the
+   students to take similar steps (e.g. for HTTP Requests one exercise
+   introduces GET, another has GET and POST etc).
 
-4. Explaining and getting the students to focus on one new thing at a time, presenting students with lots of new content and usage examples can be confusing.
+4. Explaining and getting the students to focus on one new thing at a time,
+   presenting students with lots of new content and usage examples can be
+   confusing.
 
-5. Before starting to write a new tutorial please speak with someone from codebar to see whether it is of interest to students.
+5. Before starting to write a new tutorial please speak with someone from
+   codebar to see whether it is of interest to students.
 
 ##### To add downloadable files to a new or existing tutorial:
 

--- a/README.md
+++ b/README.md
@@ -2,20 +2,34 @@ This is the source code for <http://tutorials.codebar.io>
 
 ## Getting started
 
-This is a [GitHub Pages](https://pages.github.com/) repo, so you can render the pages with [Jekyll](http://jekyllrb.com/):
+This is a [GitHub Pages](https://pages.github.com/) repo, so you can render the pages with [Jekyll](http://jekyllrb.com/).
 
-1. `bundle install`, which will install Jekyll
-2. `bundle exec jekyll serve`
-3. go to http://127.0.0.1:4000
+The recommended way of installing the project depdendencies is via [RVM](https://rvm.io/rvm/install).
+Follow the [quick installation guide](https://rvm.io/rvm/install#quick-guided-install) and then run:
 
-If you also want to make changes to the structure of the site (i.e. if you want to modify the site's Javascript files) and run the tests, first make sure you have a recent version of npm (node) installed. Then do:
+```bash
+$ rvm install 2.2.1  # inside `codebar/tutorials` folder
+$ rvm gemset use codebar-tutorial --create
+$ gem install bundler
+$ bundle install
+```
+
+In order to serve the site, you'll need to have [Node](https://nodejs.org/en/) installed.
+This can be done with a tool like [NVM](https://github.com/creationix/nvm). Then run:
+
+```bash
+$ jekyll serve  # go to http://127.0.0.1:4000
+```
+
+If you also want to make changes to the structure of the site (i.e. if you want
+to modify the site's Javascript files) and run the tests, you can:
 
 ```bash
 $ npm install
 $ gulp
 ```
 
-and then go to http://localhost:4000/test/specrunner.html to run the tests. Tests should be green.
+Then go to http://localhost:4000/test/specrunner.html to run the tests. Tests should be green.
 
 > *Gulp is only used for development, not in production. In your local copy of this repo, it will concatenate and minify the files inside the `javascripts-dev` folder, as well as watch for changes in that folder. The concatenated and minified JS file will be generated inside the `javascripts` folder. You can push both folders when you are finished with your changes. GitHub pages will then  generate the site in production with whatever is inside the `javascripts` folder.*
 
@@ -32,16 +46,16 @@ If you are not on Slack use [this link](http://codebar-slack.herokuapp.com/) to 
 We encourage you to contribute with your suggestions and corrections. Head to our [issues page](https://github.com/codebar/tutorials/issues) and open a new issue or help on the existing ones.
 
 
-##### General tutorial rule 
+##### General tutorial rule
 
-1. All tutorials get the students to build something that they are able to show around at the end of the workshop. 
+1. All tutorials get the students to build something that they are able to show around at the end of the workshop.
 
 2. All tutorials follow a structure:
 	* Objectives - "In this tutorial we are going to look at..."
-	* Goals - "By the end of this tutorial you will have..." 
-	* Then the exercises. 
+	* Goals - "By the end of this tutorial you will have..."
+	* Then the exercises.
 	* Bonus - This is not always required but if you feel there is something that could be added then please include it.
-	* Further reading - Again this is not always required but if you feel there was something in the tutorials that could be covered in more depth then please include any good reading materials/videos or extra tutorials. 
+	* Further reading - Again this is not always required but if you feel there was something in the tutorials that could be covered in more depth then please include any good reading materials/videos or extra tutorials.
 
 3. Repetition is good. A tutorial can contain multiple exercises that ask the students to take similar steps (e.g. for HTTP Requests one exercise introduces GET, another has GET and POST etc).
 


### PR DESCRIPTION
Given that `codebar/tutorials` has a number of dependencies, it should be recommended to use some isolated environment tool to not blow up the contributors machine (in the case they are just getting started with Ruby). So, I recommend RVM, it's pretty handy.

Also, I wasn't able to `jekyll serve` without an install of Node. So I added it as well.

Finally, I wrapped the text so it can more easily be read in a text editor or pager.

New rendered version can be reviewed [here](https://github.com/lwm/tutorials/blob/82e762db20a46a2c1570f1875ee0f9dd2c135cc8/README.md).