### PR TITLE
Avoid real downloads in tests

### DIFF
--- a/javascripts-dev/tests/zipper-spec.js
+++ b/javascripts-dev/tests/zipper-spec.js
@@ -3,6 +3,10 @@ describe("Zipper", function() {
 
   var zip = Zipper.zip;
 
+  beforeEach(function() {
+    spyOn(zip, "generateAsync").and.returnValue(new Promise( function() {} ));
+  });
+
   it("adds files to the zip", function() {
     spyOn(zip, "file");
     Zipper.createZip(Downloader);


### PR DESCRIPTION
There is no need to do a real download of the zip file in tests.
This PR fixes this by intercepting and simulating the download.
JavaScript-dev-relevant only change.