### PR TITLE
Added linebreaks to ensure headings render correctly.

### DIFF
--- a/html/lesson1/tutorial.md
+++ b/html/lesson1/tutorial.md
@@ -109,10 +109,15 @@ Notice how each tag is indented to its parent tag. This is important as it makes
 Headings come in 6 sizes
 
 # `<h1>Heading</h1>`
+
 ## `<h2>Heading</h2>`
+
 ### `<h3>Heading</h3>`
+
 #### `<h4>Heading</h4>`
+
 ##### `<h5>Heading</h5>`
+
 ###### `<h6>Heading</h6>`
 
 A `h1` defines the most important heading whereas a `h6` defines the least important.


### PR DESCRIPTION
The Headings section of the HTML tutorial is displaying raw markdown in the example code. Added line breaks between each example so they render correctly. 

**Before**
![headings-before](https://cloud.githubusercontent.com/assets/25522/20136918/5ffb1582-a66f-11e6-9c67-259ac844a17f.png)

**After**
![headings-after](https://cloud.githubusercontent.com/assets/25522/20136928/69c90812-a66f-11e6-9cd3-89b935605de1.png)
