### PR TITLE
Fix h1 heading in ruby tutorial

### DIFF
--- a/ruby/lesson3/tutorial.md
+++ b/ruby/lesson3/tutorial.md
@@ -49,7 +49,7 @@ end
 > Don't forget to wrap your interactions within `transaction` blocks
 
 
-# Exercise: Contacts list
+## Exercise: Contacts list
 
 Using what we have learned in the last couple of ruby lessons we will create a contact list where we can store people's names and date of birth.
 


### PR DESCRIPTION
GitHub doesn't seem to display the second `#` / h1 heading:

<img width="1109" alt="screen shot 2017-01-14 at 14 28 13" src="https://cloud.githubusercontent.com/assets/233676/21955581/eb5586a6-da65-11e6-9823-f50ebfa1bf32.png">


