### PR TITLE
Ruby now recommends Cloud9 over nitrous.io

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
 
           <h2>Ruby</h2>
 
-          <p class="lead">If you are just getting started with Ruby, we recommend using <a href="http://nitrous.io">nitrous.io</a>, as setting up your local environment can be time consuming.</p>
+          <p class="lead">If you are just getting started with Ruby, we recommend using <a href="https://c9.io/">Cloud9</a>, as setting up your local environment can be time consuming.</p>
 
           <ul>
             <li><a href="ruby/lesson1/tutorial.html">Lesson 1 - Introduction to Ruby</a></li>

--- a/index.pt.html
+++ b/index.pt.html
@@ -56,7 +56,7 @@
 
           <strong>Ruby</strong>
 
-          <p class="lead">Se você está começando agora com Ruby, recomendamos usar <a href="http://nitrous.io">nitrous.io</a>, já que a preparação do seu ambiente local pode levar tempo.</p>
+          <p class="lead">Se você está começando agora com Ruby, recomendamos usar <a href="https://c9.io/">Cloud9</a>, já que a preparação do seu ambiente local pode levar tempo.</p>
 
           <ul>
             <li><a href="ruby/lesson1/tutorial.html">Introdução ao Ruby</a></li>


### PR DESCRIPTION
nitrous.io is no more, I recommend Cloud9 instead.