### PR TITLE
Link fixes: changed HTTP to HTTPS, removed a dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@ This is the source code for <http://tutorials.codebar.io>
 
 ## Getting started
 
-This is a [GitHub Pages](https://pages.github.com/) repo, so you can render the pages with [Jekyll](http://jekyllrb.com/).
+This is a [GitHub Pages](https://pages.github.com/) repo, so you can render the pages with [Jekyll](https://jekyllrb.com/).
 First make sure to [install the version of Ruby](https://www.ruby-lang.org/en/documentation/installation/)
-indicated in `.ruby-version`, as well as the [bundler](http://bundler.io/) gem. Then:
+indicated in `.ruby-version`, as well as the [bundler](https://bundler.io/) gem. Then:
 
 1. `bundle install`, which will install Jekyll
 2. `bundle exec jekyll serve --watch`
@@ -135,4 +135,4 @@ This can be done with a tool like [NVM](https://github.com/creationix/nvm).
 
 ## License
 
-codebar Tutorials are released under the [Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)](http://creativecommons.org/licenses/by-nc-sa/4.0/).
+codebar Tutorials are released under the [Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)](https://creativecommons.org/licenses/by-nc-sa/4.0/).

--- a/android/1introduction/tutorial.md
+++ b/android/1introduction/tutorial.md
@@ -15,7 +15,7 @@ arriving at the workshop!)
 If you want to run your app on your own phone, remember to enable USB debugging in the device system settings, under Settings -> Developer options.
 (please note: On Android 4.2 and newer, Developer options is hidden by default. To make it available, go to Settings -> About phone and tap Build number seven times. Return to the previous screen to find Developer options.)
 
-Feel free to chose a different topic other than cookies, we really like the popular pokémon [Goomy Clicker](http://joezeng.github.io/goomyclicker) - what things do you like?
+Feel free to chose a different topic other than cookies, we really like the popular pokémon [Goomy Clicker](https://joezeng.github.io/goomyclicker) - what things do you like?
 
 ![Imgur](http://i.imgur.com/ssQF3jO.png)
 

--- a/general/setup/tutorial.md
+++ b/general/setup/tutorial.md
@@ -25,7 +25,7 @@ We recommend you use **[Atom](https://atom.io/)** at codebar. It's free, open so
 
 ## A web browser (required)
 
-You'll have one of these already! Windows comes with [Internet Explorer](http://windows.microsoft.com/en-us/internet-explorer/), and OS X comes with [Safari](https://www.apple.com/uk/safari/). Most Linux distributions come with [Firefox](https://www.mozilla.org/en-US/firefox/), which is also available for Windows and OS X. You can also download [Chrome](https://www.google.com/chrome/) which is a popular alternative. You can get started with whatever you currently use, but when you reach the later tutorials the powerful developer tools in Chrome and Firefox will be useful. Your coach will show you how to use them while you work through the tutorials.
+You'll have one of these already! Windows comes with [Internet Explorer](https://windows.microsoft.com/en-us/internet-explorer/), and OS X comes with [Safari](https://www.apple.com/uk/safari/). Most Linux distributions come with [Firefox](https://www.mozilla.org/en-US/firefox/), which is also available for Windows and OS X. You can also download [Chrome](https://www.google.com/chrome/) which is a popular alternative. You can get started with whatever you currently use, but when you reach the later tutorials the powerful developer tools in Chrome and Firefox will be useful. Your coach will show you how to use them while you work through the tutorials.
 
 ## A compression utility (handy on Windows)
 

--- a/general/setup/tutorial.pt.md
+++ b/general/setup/tutorial.pt.md
@@ -25,7 +25,7 @@ Nós recomendamos usar **[Atom](https://atom.io/)** no Codebar. É de graça, te
 
 ## Um navegador de internet (obrigatório)
 
-Você já tem um desses! O Windows vem com o [Internet Explorer](http://windows.microsoft.com/pt-br/internet-explorer/), e o OS X vem com  [Safari](https://www.apple.com/br/safari/). [Firefox](https://www.mozilla.org/pt-BR/firefox/new/) e [Chrome](https://www.google.com.br/intl/pt-BR/chrome/) são alternativas populares. Você pode começar com qualquer um que já use, mas quando você chegar nos últimos tutoriais, as ferramentas poderosas do Chrome e Firefox vão ser úteis. Seu tutor vai te mostrar como usá-las quando vocês estiverem trabalhando nestes tutoriais.
+Você já tem um desses! O Windows vem com o [Internet Explorer](https://windows.microsoft.com/pt-br/internet-explorer/), e o OS X vem com  [Safari](https://www.apple.com/br/safari/). [Firefox](https://www.mozilla.org/pt-BR/firefox/new/) e [Chrome](https://www.google.com.br/intl/pt-BR/chrome/) são alternativas populares. Você pode começar com qualquer um que já use, mas quando você chegar nos últimos tutoriais, as ferramentas poderosas do Chrome e Firefox vão ser úteis. Seu tutor vai te mostrar como usá-las quando vocês estiverem trabalhando nestes tutoriais.
 
 ## Ferramenta de compactação (importante para Windows)
 

--- a/html/lesson1/example-styled.html
+++ b/html/lesson1/example-styled.html
@@ -20,7 +20,7 @@
     <div style="display: inline;"><img src="images/img4.jpg"></div>
     <div style="display: inline;"><img src="images/img5.jpg"></div>
     <div style="margin-top: 20px">
-      <a href="http://www.youtube.com/watch?v=gBjnfgnwXic">Watch this video here</a>
+      <a href="https://www.youtube.com/watch?v=gBjnfgnwXic">Watch this video here</a>
     </div>
     <h4>
       <i>&#34;A wise old owl sat on an oak;  The more he saw the less he spoke; <br>
@@ -36,7 +36,7 @@
         the owl's forward-facing <strong>eyes permits the greater <br>
         sense of depth perception </strong>necessary for low-light hunting. <br>
         <br>
-        <a href="http://en.wikipedia.org/wiki/Owl">More information about owls...</a>
+        <a href="https://en.wikipedia.org/wiki/Owl">More information about owls...</a>
       </p>
     </div>
     <div style="width: 30%; display: inline">

--- a/html/lesson1/example-styled.pt.html
+++ b/html/lesson1/example-styled.pt.html
@@ -21,7 +21,7 @@
     <div style="display: inline;"><img src="images/img4.jpg"></div>
     <div style="display: inline;"><img src="images/img5.jpg"></div>
     <div style="margin-top: 20px">
-      <a href="http://www.youtube.com/watch?v=gBjnfgnwXic">Assista o vídeo</a>
+      <a href="https://www.youtube.com/watch?v=gBjnfgnwXic">Assista o vídeo</a>
     </div>
     <h4>
       <i>&#34;Uma coruja sábia e anciã pousou em um carvalho; Quanto mais observava, menos falava; <br>
@@ -37,7 +37,7 @@
         <strong>olhos voltados para frente na coruja permite<br/>
         um melhor senso de percepção profunda</strong> necessária para a caça com pouca luz.<br>
         <br>
-        <a href="http://pt.wikipedia.org/wiki/Coruja">Mais informações sobre corujas...</a>
+        <a href="https://pt.wikipedia.org/wiki/Coruja">Mais informações sobre corujas...</a>
       </p>
     </div>
     <div style="width: 30%; display: inline">

--- a/html/lesson1/example.html
+++ b/html/lesson1/example.html
@@ -18,7 +18,7 @@
       <li><b>and cuddly</b></li>
     <div><img src="images/img4.jpg" alt="cute owl"/></div>
     <div><img src="images/img5.jpg" alt="another cute owl"/></div>
-    <a href="http://www.youtube.com/watch?v=gBjnfgnwXic">Watch this video here</a>
+    <a href="https://www.youtube.com/watch?v=gBjnfgnwXic">Watch this video here</a>
     </ol>
     <h4>
       <i>&#34;A wise old owl sat on an oak;  The more he saw the less he spoke; <br>
@@ -34,7 +34,7 @@
         the owl's forward-facing <strong>eyes permits the greater <br>
         sense of depth perception </strong>necessary for low-light hunting. <br>
         <br>
-        <a href="http://en.wikipedia.org/wiki/Owl">More information about owls...</a>
+        <a href="https://en.wikipedia.org/wiki/Owl">More information about owls...</a>
       </p>
     </div>
     <div>

--- a/html/lesson1/example.pt.html
+++ b/html/lesson1/example.pt.html
@@ -19,7 +19,7 @@
       <li><b>e apertáveis</b></li>
     <div><img src="images/img4.jpg"></div>
     <div><img src="images/img5.jpg"></div>
-    <a href="http://www.youtube.com/watch?v=gBjnfgnwXic">Assista o vídeo</a>
+    <a href="https://www.youtube.com/watch?v=gBjnfgnwXic">Assista o vídeo</a>
     </ol>
     <h4>
       <i>&#34;Uma coruja sábia e anciã pousou em um carvalho; Quanto mais observava, menos falava; <br>
@@ -35,7 +35,7 @@
         <strong>olhos voltados para frente na coruja permite<br/>
         um melhor senso de percepção profunda</strong> necessária para a caça com pouca luz.<br>
         <br>
-        <a href="http://pt.wikipedia.org/wiki/Coruja">Mais informações sobre corujas...</a>
+        <a href="https://pt.wikipedia.org/wiki/Coruja">Mais informações sobre corujas...</a>
       </p>
     </div>
     <div>

--- a/html/lesson1/tutorial.md
+++ b/html/lesson1/tutorial.md
@@ -56,7 +56,7 @@ It tells the browser which version of HTML the page is using.
 <!DOCTYPE html>
 ```
 
-We will only be using html for now, but you can find more about doctypes [here](http://www.w3.org/wiki/Doctypes_and_markup_styles).
+We will only be using html for now, but you can find more about doctypes [here](https://www.w3.org/wiki/Doctypes_and_markup_styles).
 
 The doctype is always followed by the `<html>` tag, which contains the contents of your page.
 
@@ -145,7 +145,7 @@ A link lets the user click through to another webpage. We use the attribute `hre
 Let's add a link to the bottom of your paragraph:
 
 ```html
-<a href="http://en.wikipedia.org/wiki/Owl">More information about owls...</a>
+<a href="https://en.wikipedia.org/wiki/Owl">More information about owls...</a>
 ```
 
 ### Element: Div `<div>`
@@ -161,7 +161,7 @@ Wrap your existing paragraph and link in a div and add a new heading to it.
     Most birds of prey sport eyes on the sides of their heads,
     but the stereoscopic nature of the owl's forward-facing eyes permits the greater
     sense of depth perception necessary for low-light hunting.
-    <a href="http://en.wikipedia.org/wiki/Owl">More information about owls...</a>
+    <a href="https://en.wikipedia.org/wiki/Owl">More information about owls...</a>
   </p>
 </div>
 ```
@@ -236,7 +236,7 @@ Add this underneath the ordered list about why we like owls.
 
 ```html
 <div>
-  <a href="http://www.youtube.com/watch?v=gBjnfgnwXic">
+  <a href="https://www.youtube.com/watch?v=gBjnfgnwXic">
     <img src="images/img4.jpg" alt="cute owl">
     <img src="images/img5.jpg" alt="another cute owl">
     <br>

--- a/html/lesson1/tutorial.pt.md
+++ b/html/lesson1/tutorial.pt.md
@@ -68,7 +68,7 @@ Ele diz ao navegador qual a versão de HTML a página está usando.
 <!DOCTYPE html>
 ```
 
-Por enquanto nós vamos usar somente HTML, mas você pode descobrir mais sobre doctypes [aqui](http://www.w3.org/wiki/Doctypes_and_markup_styles).
+Por enquanto nós vamos usar somente HTML, mas você pode descobrir mais sobre doctypes [aqui](https://www.w3.org/wiki/Doctypes_and_markup_styles).
 
 O doctype vem sempre seguido pela tag `<html>`, a qual já tem o conteúdo da página.
 
@@ -186,7 +186,7 @@ Vamos adicionar um link no final do nosso parágrafo
 
 ```html
 <br/>
-<a href="http://pt.wikipedia.org/wiki/Coruja">Mais informações sobre corujas...</a>
+<a href="https://pt.wikipedia.org/wiki/Coruja">Mais informações sobre corujas...</a>
 ```
 
 ### Elemento: Div `<div>`
@@ -206,7 +206,7 @@ Cerque o parágrafo já existente por um div e adicione um novo cabeçalho a ele
     <strong>olhos voltados para frente na coruja permite<br/>
     um melhor senso de percepção profunda</strong> necessária para a caça com pouca luz.
     <br/>
-    <a href="http://pt.wikipedia.org/wiki/Coruja">Mais informações sobre corujas...</a>
+    <a href="https://pt.wikipedia.org/wiki/Coruja">Mais informações sobre corujas...</a>
   </p>
 </div>
 ```
@@ -289,7 +289,7 @@ Adicione este texto abaixo da lista ordenada sobre porque gostamos de corujas.
 
 ```html
 <div>
-  <a href="http://www.youtube.com/watch?v=gBjnfgnwXic">
+  <a href="https://www.youtube.com/watch?v=gBjnfgnwXic">
     <img src="images/img4.jpg" alt="coruja fofa"/>
     <img src="images/img5.jpg" alt="outra coruja fofa"/>
     <br/>

--- a/html/lesson2/example.html
+++ b/html/lesson2/example.html
@@ -22,7 +22,7 @@
       </ol>
       <div><img src="images/img4.jpg" alt="cute owl"/></div>
       <div><img src="images/img5.jpg" alt="another cute owl"/></div>
-      <a href="http://www.youtube.com/watch?v=gBjnfgnwXic">Watch this video here</a>
+      <a href="https://www.youtube.com/watch?v=gBjnfgnwXic">Watch this video here</a>
       <div id="the-quote">
         <h4>
           <i>&#34;A wise old owl sat on an oak;  The more he saw the less he spoke; <br>
@@ -40,7 +40,7 @@
             the owl's forward-facing <strong>eyes permits the greater <br>
             sense of depth perception </strong>necessary for low-light hunting. <br>
             <br>
-            <a href="http://en.wikipedia.org/wiki/Owl">More information about owls...</a>
+            <a href="https://en.wikipedia.org/wiki/Owl">More information about owls...</a>
           </p>
         </div>
         <ul id="links">

--- a/html/lesson3/example.html
+++ b/html/lesson3/example.html
@@ -19,13 +19,13 @@
         <strong> Me on the internet</strong>
         <ul class="social-media">
           <li><a href="https://www.facebook.com/augusta.ada.lovelace">facebook</a> </li>
-          <li><a href="http://en.wikipedia.org/wiki/Ada_Lovelace">wikipedia</a> </li>
+          <li><a href="https://en.wikipedia.org/wiki/Ada_Lovelace">wikipedia</a> </li>
         </ul>
       </div>
       <div class="main">
         <p>My name is August Ada King. I'm the Countess of Lovelace.</p>
 
-        <p>I am a mathematician and a writer. People know me from my work on <a href="http://en.wikipedia.org/wiki/Charles_Babbage">Charle's Babbage's</a> early mechanical general-purpose computer, the Analytical engine. I wrote the first algorithm intended to be processed by a machine. In other words,<span class="highlight"> I am the world's first programmer</span>. </p>
+        <p>I am a mathematician and a writer. People know me from my work on <a href="https://en.wikipedia.org/wiki/Charles_Babbage">Charle's Babbage's</a> early mechanical general-purpose computer, the Analytical engine. I wrote the first algorithm intended to be processed by a machine. In other words,<span class="highlight"> I am the world's first programmer</span>. </p>
 
         <p>My mother, Anne Isabella Byron, was a great help to me as she helped me by promoting my interest in mathematics and logic, but I also never forgot about my dad, who moved to Greece when I was just an infant to help out in the civil war.</p>
 
@@ -43,12 +43,12 @@
         </span>
         </p>
 
-        <p>The computer language <a href="http://en.wikipedia.org/wiki/Ada_(programming_language)">Ada</a>, was named after me. The Defense Military standard for the language, MIL-STD-1815 was also given the year of my birth.</p>
+        <p>The computer language <a href="https://en.wikipedia.org/wiki/Ada_(programming_language)">Ada</a>, was named after me. The Defense Military standard for the language, MIL-STD-1815 was also given the year of my birth.</p>
 
-        <p>These days, the British Computer Society runs an annual competitions for women students of computer science in my name. Also, the annual conference for women undergraduates is named after me. Google also dedicated its <a href="http://www.google.com/doodles/ada-lovelaces-197th-birthday">Google doodle</a> to me, on the 197th anniversary of my birth. </p>
+        <p>These days, the British Computer Society runs an annual competitions for women students of computer science in my name. Also, the annual conference for women undergraduates is named after me. Google also dedicated its <a href="https://www.google.com/doodles/ada-lovelaces-197th-birthday">Google doodle</a> to me, on the 197th anniversary of my birth. </p>
 
         <p class="google-doodle">
-          <a href="http://www.google.com/doodles/ada-lovelaces-197th-birthday"><img src="http://www.google.com/logos/2012/ada_lovelaces_197th_birthday-991005-hp.jpg" /></a>
+          <a href="https://www.google.com/doodles/ada-lovelaces-197th-birthday"><img src="https://www.google.com/logos/2012/ada_lovelaces_197th_birthday-991005-hp.jpg" /></a>
         </p>
       </div>
     </div>

--- a/html/lesson3/tutorial.md
+++ b/html/lesson3/tutorial.md
@@ -35,7 +35,7 @@ In the previous two lessons, we spoke about **H**yper **T**ext **M**arkup **L**a
 
 Inspectors are development tools that help you view, edit and debug CSS, HTML and JavaScript.
 
-Chrome Devtools are already built into your Chrome browser, or Inspector if you are using Firefox. For advanced users, many other tools are available as browser plugins, including the Firefox add-on [Firebug](http://getfirebug.com/).
+Chrome Devtools are already built into your Chrome browser, or Inspector if you are using Firefox. For advanced users, many other tools are available as browser plugins, including the Firefox add-on [Firebug](https://getfirebug.com/).
 
 ![](assets/images/chrome-devtools.png)
 
@@ -230,7 +230,7 @@ Let's add some content! Add the following inside the `div` in the html file
   <strong>Me on the internet</strong>
   <ul>
    <li><a href="https://www.facebook.com/augusta.ada.lovelace">facebook</a> </li>
-   <li><a href="http://en.wikipedia.org/wiki/Ada_Lovelace">wikipedia</a> </li>
+   <li><a href="https://en.wikipedia.org/wiki/Ada_Lovelace">wikipedia</a> </li>
  </ul>
 </div>
 ```
@@ -440,7 +440,7 @@ vertical-align: top;
 Add a link so that anyone coming to the page can easily find out more about Charles Babbage. In the second paragraph, wrap his name in a link as shown below.
 
 ```html
-<a href="http://en.wikipedia.org/wiki/Charles_Babbage">Charles Babbage's </a>
+<a href="https://en.wikipedia.org/wiki/Charles_Babbage">Charles Babbage's </a>
 ```
 
 Ada was the world's first programmer therefore we want that to stand out. Add a span around it and specify a class `highlight`, so the intention is obvious and other people working on the code of the page can easily understand it.
@@ -514,13 +514,13 @@ Make the poem look different than the rest of the text. Add a CSS class `poem` t
 
 ### Some more information about Ada
 ```html
-<p>The computer language <a href="http://en.wikipedia.org/wiki/Ada_(programming_language)">Ada</a>, was named after me. The Defense Military standard for the language, MIL-STD-1815 was also given the year of my birth.</p>
+<p>The computer language <a href="https://en.wikipedia.org/wiki/Ada_(programming_language)">Ada</a>, was named after me. The Defense Military standard for the language, MIL-STD-1815 was also given the year of my birth.</p>
 
-<p>These days, the British Computer Society runs an annual competitions for women students of computer science in my name. Also, the annual conference for women undergraduates is named after me. Google also dedicated its <a href="http://www.google.com/doodles/ada-lovelaces-197th-birthday">Google doodle</a> to me, on the 197th anniversary of my birth. </p>
+<p>These days, the British Computer Society runs an annual competitions for women students of computer science in my name. Also, the annual conference for women undergraduates is named after me. Google also dedicated its <a href="https://www.google.com/doodles/ada-lovelaces-197th-birthday">Google doodle</a> to me, on the 197th anniversary of my birth. </p>
 
 <p>
- <a href="http://www.google.com/doodles/ada-lovelaces-197th-birthday">
-  <img src="http://www.google.com/logos/2012/ada_lovelaces_197th_birthday-991005-hp.jpg">
+ <a href="https://www.google.com/doodles/ada-lovelaces-197th-birthday">
+  <img src="https://www.google.com/logos/2012/ada_lovelaces_197th_birthday-991005-hp.jpg">
  </a>
 </p>
 ```

--- a/html/lesson4/example.html
+++ b/html/lesson4/example.html
@@ -15,9 +15,9 @@
     <div id="resources">
       <ul>
         <li><a href="http://www.cs.yale.edu/homes/tap/Files/hopper-story.html">Computer Scientist</a></li>
-        <li><a href="http://www.youtube.com/watch?v=1-vcErOPofQ">Grace Hopper on Letterman</a></li>
-        <li><a href="http://en.wikipedia.org/wiki/Grace_Hopper">Wikipedia</a></li>
-        <li><a href="http://en.wikiquote.org/wiki/Grace_Hopper">Wikiquote</a></li>
+        <li><a href="https://www.youtube.com/watch?v=1-vcErOPofQ">Grace Hopper on Letterman</a></li>
+        <li><a href="https://en.wikipedia.org/wiki/Grace_Hopper">Wikipedia</a></li>
+        <li><a href="https://en.wikiquote.org/wiki/Grace_Hopper">Wikiquote</a></li>
       </ul>
     </div>
     </header>

--- a/html/lesson4/tutorial.md
+++ b/html/lesson4/tutorial.md
@@ -168,9 +168,9 @@ This should be placed before the header closing tag.
 <div>
   <ul>
     <li> <a href="http://www.cs.yale.edu/homes/tap/Files/hopper-story.html">Computer Scientist</a></li>
-    <li> <a href="http://www.youtube.com/watch?v=1-vcErOPofQ">Grace Hopper on Letterman</a></li>
-    <li> <a href="http://en.wikipedia.org/wiki/Grace_Hopper">Wikipedia</a></li>
-    <li> <a href="http://en.wikiquote.org/wiki/Grace_Hopper">Wikiquote</a></li>
+    <li> <a href="https://www.youtube.com/watch?v=1-vcErOPofQ">Grace Hopper on Letterman</a></li>
+    <li> <a href="https://en.wikipedia.org/wiki/Grace_Hopper">Wikipedia</a></li>
+    <li> <a href="https://en.wikiquote.org/wiki/Grace_Hopper">Wikiquote</a></li>
   </ul>
 </div>
 ```

--- a/html/lesson5/example.html
+++ b/html/lesson5/example.html
@@ -11,7 +11,7 @@
         <img class="rounded" src="assets/images/anita-bottom.jpg"/>
         <div class="references">
           <a class="btn" href="http://gos.sbc.edu/b/borg.html">reference</a>
-          <a class="btn" href="http://en.wikipedia.org/wiki/Anita_Borg">wikipedia</a>
+          <a class="btn" href="https://en.wikipedia.org/wiki/Anita_Borg">wikipedia</a>
         </div>
       </div>
       <div id="container">

--- a/html/lesson5/tutorial.md
+++ b/html/lesson5/tutorial.md
@@ -118,7 +118,7 @@ Add this right after the beginning of the element with the id `wrapper`
   <img src="anita-bottom.jpg" alt="Anita Borg image 2">
   <div>
     <a href="http://gos.sbc.edu/b/borg.html">reference</a>
-    <a href="http://en.wikipedia.org/wiki/Anita_Borg">wikipedia</a>
+    <a href="https://en.wikipedia.org/wiki/Anita_Borg">wikipedia</a>
   </div>
 </div>
 ```

--- a/html/lesson7/example.html
+++ b/html/lesson7/example.html
@@ -40,13 +40,13 @@
                         <a class="resourcelist_link" href="http://www.cs.yale.edu/homes/tap/Files/hopper-story.html">Computer Scientist</a>
                     </li>
                     <li class="resourcelist_item">
-                        <a class="resourcelist_link" href="http://www.youtube.com/watch?v=1-vcErOPofQ">Grace Hopper on Letterman</a>
+                        <a class="resourcelist_link" href="https://www.youtube.com/watch?v=1-vcErOPofQ">Grace Hopper on Letterman</a>
                     </li>
                     <li class="resourcelist_item">
-                        <a class="resourcelist_link" href="http://en.wikipedia.org/wiki/Grace_Hopper">Wikipedia</a>
+                        <a class="resourcelist_link" href="https://en.wikipedia.org/wiki/Grace_Hopper">Wikipedia</a>
                     </li>
                     <li class="resourcelist_item">
-                        <a class="resourcelist_link" href="http://en.wikiquote.org/wiki/Grace_Hopper">Wikiquote</a>
+                        <a class="resourcelist_link" href="https://en.wikiquote.org/wiki/Grace_Hopper">Wikiquote</a>
                     </li>
                 </ul>
             </div>

--- a/html/lesson7/tutorial.md
+++ b/html/lesson7/tutorial.md
@@ -414,8 +414,8 @@ Media queries can take more than one expression, for example `@media screen and 
 ## Further work
 Why not try adding a navigation menu to your page? It could have a list of links that are vertical on mobile and horizontal on desktop. You could even try making them collapse on mobile.
 
-(eg <a href="http://codepen.io/thisisjofrank/pen/vXVmXP" target="_blank">Example on Codepen</a>)
+(eg <a href="https://codepen.io/thisisjofrank/pen/vXVmXP" target="_blank">Example on Codepen</a>)
 
 If you're looking for something a little more silly how about making the background of your site flash through the rainbow as you drag the browser width?
 
-(eg <a href="http://codepen.io/thisisjofrank/pen/RGQJvY" target="_blank">Example on Codepen</a>)
+(eg <a href="https://codepen.io/thisisjofrank/pen/RGQJvY" target="_blank">Example on Codepen</a>)

--- a/index.html
+++ b/index.html
@@ -61,8 +61,6 @@
         </ul>
 
         <h2>Ruby</h2>
-        <p class="lead">If you are just getting started with Ruby, we recommend using <a href="https://nitrous.io">nitrous.io</a>, as setting up your local environment can be time consuming.</p>
-
         <ul>
           <li><a href="ruby/lesson1/tutorial.html">Lesson 1 - Introduction to Ruby</a></li>
           <li><a href="ruby/lesson2/tutorial.html">Lesson 2 - Ruby Basics</a></li>

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
         </ul>
 
         <h2>Ruby</h2>
-        <p class="lead">If you are just getting started with Ruby, we recommend using <a href="http://nitrous.io">nitrous.io</a>, as setting up your local environment can be time consuming.</p>
+        <p class="lead">If you are just getting started with Ruby, we recommend using <a href="https://nitrous.io">nitrous.io</a>, as setting up your local environment can be time consuming.</p>
 
         <ul>
           <li><a href="ruby/lesson1/tutorial.html">Lesson 1 - Introduction to Ruby</a></li>

--- a/js/lesson3/tutorial.md
+++ b/js/lesson3/tutorial.md
@@ -172,7 +172,7 @@ box. That's a bit annoying. Use jQuery's `focus()` method to place the
 cursor back in the text field after clicking the button.
 
 If you aren't sure how to use the focus() method, try searching for it
-in the [jQuery documentation](http://api.jquery.com/). There are some
+in the [jQuery documentation](https://api.jquery.com/). There are some
 code examples illustrating how to use it.
 
 ## Label items
@@ -654,9 +654,9 @@ Here are the things you learned about in exercise 2:
 
 If you want to use jQuery on other projects, you can download or link
 directly to the latest version from the
-[jQuery download section](http://jquery.com/download/).
+[jQuery download section](https://jquery.com/download/).
 
-You can read the [jQuery documentation](http://api.jquery.com/) to
+You can read the [jQuery documentation](https://api.jquery.com/) to
 look up what other things can be done with jQuery. The page for every
 jQuery method has examples of how to use it (maybe below a long
 explanation of what it does - scroll down to find the examples).

--- a/js/lesson7/tutorial.md
+++ b/js/lesson7/tutorial.md
@@ -13,7 +13,7 @@ Today we will be briefly explaining how you can test-drive your code. Testing is
 
 ## JavaScript Testing Frameworks
 
-There are [a number](http://en.wikipedia.org/wiki/List_of_unit_testing_frameworks#JavaScript) of libraries written to assist with testing JavaScript, but we will use [Jasmine](http://jasmine.github.io/). The syntax is quite simple and it doesn't require any additional configuration in order to use.
+There are [a number](https://en.wikipedia.org/wiki/List_of_unit_testing_frameworks#JavaScript) of libraries written to assist with testing JavaScript, but we will use [Jasmine](https://jasmine.github.io/). The syntax is quite simple and it doesn't require any additional configuration in order to use.
 
 ## Jasmine
 
@@ -126,7 +126,7 @@ kms = miles * 1.609
 
 # Test matchers
 
-Besides the `toEqual()` method, Jasmine has a big set of matchers that we can use to verify the results of our tests like `toBe()`, `not.toBe()`, `toBeNull()` and [a lot of others](http://pivotal.github.io/jasmine/)
+Besides the `toEqual()` method, Jasmine has a big set of matchers that we can use to verify the results of our tests like `toBe()`, `not.toBe()`, `toBeNull()` and [a lot of others](https://jasmine.github.io/2.5/introduction#section-Included_Matchers)
 
 
 # Exercise 2: Calculator

--- a/js/lesson8/tutorial.md
+++ b/js/lesson8/tutorial.md
@@ -21,16 +21,16 @@ There is an abundance of resources out there that can help you out, but all you 
 
 Some tools out there that you can use are:
 
-- [balsamiq](http://balsamiq.com/)
-- [gomockingbird](http://gomockingbird.com/)
-- [mockflow](http://mockflow.com/pricing/)
+- [Balsamiq](https://balsamiq.com/)
+- [GoMockingbird](https://gomockingbird.com/)
+- [Mockflow](https://mockflow.com/pricing/)
 
 However, using pen and paper is probably the easiest way, so try and choose whatever is easier for you!
 
 
 ## Tracking your tasks
 
-It's important to keep organised and remember what you intend to build. Try and make a list of your tasks. You can keep track using [Github's issues](https://github.com/blog/831-issues-2-0-the-next-generation) or applications like [trello](https://trello.com/) or [pivotal tracker](http://www.pivotaltracker.com/). You can use all these tools for free and it's an easy and efficient way of not just remembering everything but also of communicating to others that may be interested in helping you out what it is that you want to achieve.
+It's important to keep organised and remember what you intend to build. Try and make a list of your tasks. You can keep track using [Github's issues](https://github.com/blog/831-issues-2-0-the-next-generation) or applications like [Trello](https://trello.com/) or [Pivotal Tracker](https://www.pivotaltracker.com/). You can use all these tools for free and it's an easy and efficient way of not just remembering everything but also of communicating to others that may be interested in helping you out what it is that you want to achieve.
 
 ## Storing data
 
@@ -63,7 +63,7 @@ Everyone likes effects. Have a look at [jQuery's effects](http://api.jquery.com/
 
 ## Tracking who visited your website
 
-[Google Analytics](http://www.google.com/analytics/) is a free tool you can use to check who visited your site. To get an analytics id, you just need to create your own account and follow the information on the website.
+[Google Analytics](https://www.google.com/analytics/) is a free tool you can use to check who visited your site. To get an analytics id, you just need to create your own account and follow the information on the website.
 
 > Adding analytics can be one of the tasks when planning your project.
 
@@ -77,18 +77,18 @@ When working with someone else it's also nice to do your work in branches so you
 
 ## Useful APIs
 
-In our previous tutorials we briefly introduced the [Github](http://developer.github.com/v3/) and [BBC](http://www.bbc.co.uk/developer/technology/apis.html) APIs. Most services that you have encountered are likely to have an API available, so just try searching google for it.
+In our previous tutorials we briefly introduced the [Github](https://developer.github.com/v3/) and [BBC](http://www.bbc.co.uk/developer/technology/apis.html) APIs. Most services that you have encountered are likely to have an API available, so just try searching Google for it.
 
 Some popular API's that you may find useful
 
 - [Google Maps](https://developers.google.com/maps/) Get directions, map images, places of interest and a lot more information about places.
 
-- [twilio](http://www.twilio.com/docs/api/rest) Initiate calls and send text messages.
+- [Twilio](https://www.twilio.com/docs/api/rest) Initiate calls and send text messages.
 
-- [twitter](https://dev.twitter.com/docs/api/1.1) search twitter, retrieve and send your tweets and a lot more.
+- [Twitter](https://dev.twitter.com/docs/api/1.1) search Twitter, retrieve and send your tweets and a lot more.
 - [Spotify](https://developer.spotify.com/technologies/web-api/) Explore Spotify's music catalog and retrieve track, album and artist data.
 
-- [instagram](http://instagram.com/developer/endpoints/) Search and retrieve images from instagram.
+- [Instagram](https://instagram.com/developer/endpoints/) Search and retrieve images from Instagram.
 
 > A lot of these API's require registering your application before you are able to use them, and some may take a while to respond. You can always read up and use fake data (by creating your own JSON objects, like we learned on the [Beginning JavaScript tutorial](http://codebar.github.io/tutorials/js/lesson2/tutorial.html).
 

--- a/ruby/lesson1/tutorial.md
+++ b/ruby/lesson1/tutorial.md
@@ -23,5 +23,5 @@ The tutorial is open source, so if you have anything to add to it, you can issue
 ---
 This ends our **Introduction to Ruby** tutorial. Is there something you don't understand? Try and go through the provided resources with your coach. If you have any feedback, or can think of ways to improve this tutorial [send us an email](mailto:feedback@codebar.io) and let us know.
 
-[1]: http://rvm.io/rvm/install "Ruby Version Manager"
+[1]: https://rvm.io/rvm/install "Ruby Version Manager"
 [2]: https://github.com/sstephenson/rbenv "rbenv"

--- a/ruby/lesson2/tutorial.md
+++ b/ruby/lesson2/tutorial.md
@@ -247,5 +247,5 @@ If you are working through this at home you can ask for help in our [gitter chan
 ---
 This ends our **Ruby basics** tutorial. Is there something you don't understand? Try and go through the provided resources with your coach. If you have any feedback, or can think of ways to improve this tutorial [send us an email](mailto:feedback@codebar.io) and let us know.
 
-[1]: http://rvm.io/rvm/install "Ruby Version Manager"
+[1]: https://rvm.io/rvm/install "Ruby Version Manager"
 [2]: https://github.com/sstephenson/rbenv "rbenv"

--- a/version-control/command-line/tutorial.md
+++ b/version-control/command-line/tutorial.md
@@ -72,7 +72,7 @@ $ git log
 
 ### Transferring project repository to an online service
 
-First you need to create an account to the service of your choice ([GitHub](http://github.com/join), [GitLab](http://gitlab.com)). Then, create a new project (or repository).
+First you need to create an account to the service of your choice ([GitHub](https://github.com/join), [GitLab](https://gitlab.com)). Then, create a new project (or repository).
 
 Copy the information about adding an existing project to the repository which should be something like the details below.
 

--- a/version-control/introduction/tutorial.md
+++ b/version-control/introduction/tutorial.md
@@ -25,13 +25,13 @@ Scroll through the revisions, from the bottom up. You should be able to see each
 
 ### Wikipedia page history
 Wikipedia also holds a history of all changes.
-- Go to [this document](http://en.wikipedia.org/wiki/Women_in_computing)
+- Go to [this document](https://en.wikipedia.org/wiki/Women_in_computing)
 - Click **view history**
 
 ![](images/wikipedia-view-history.png)
 
 - Try and have a look at the first revision of the page, by going back. It's dated back to 2005!
-- Click **curr**, that will show you the [differences between the first and the latest entry](http://en.wikipedia.org/w/index.php?title=Women_in_computing&diff=583521812&oldid=19298328)
+- Click **curr**, that will show you the [differences between the first and the latest entry](https://en.wikipedia.org/w/index.php?title=Women_in_computing&diff=583521812&oldid=19298328)
 
 ![](images/wikipedia-diff.png)
 
@@ -96,9 +96,9 @@ Try using messages like _repositioned image to look better on page_, _resolved p
 
 # The next step!
 
-Sign up to [github](http://github.com/)
+Sign up to [Github](https://github.com/)
 
-Download [Github for Windows](http://windows.github.com/) or [Github for Mac](http://mac.github.com/)
+Download [Github Desktop](https://desktop.github.com/) (for Mac or Windows).
 
 ## Now what?
 


### PR DESCRIPTION
For sites like Wikipedia, YouTube and others where HTTPS is now the default, I've changed the links over to HTTPS.

I've removed the link to nitrous.io cloud IDE as that service has been closed.