### PR TITLE
Enable syntax highlighting of a CSS code block

### DIFF
--- a/html/lesson3/tutorial.md
+++ b/html/lesson3/tutorial.md
@@ -307,7 +307,7 @@ ul.social-media {
 
 Add a bottom border, to give the effect of a line, to the individual list items and tweak its dimensions
 
-```
+```css
 .social-media li {
   border-bottom: 1px solid #b0afc0;
   padding: 10px;


### PR DESCRIPTION
A missing `css` language specifier was added to a code block.