### PR TITLE
HTML[1]: close ol element in correct place

### DIFF
--- a/html/lesson1/example.html
+++ b/html/lesson1/example.html
@@ -16,10 +16,10 @@
       <li><b>they are adorable</b></li>
       <li><b>and lovely</b></li>
       <li><b>and cuddly</b></li>
+    </ol>
     <div><img src="images/img4.jpg" alt="cute owl"/></div>
     <div><img src="images/img5.jpg" alt="another cute owl"/></div>
     <a href="https://www.youtube.com/watch?v=gBjnfgnwXic">Watch this video here</a>
-    </ol>
     <h4>
       <i>&#34;A wise old owl sat on an oak;  The more he saw the less he spoke; <br>
          The less he spoke the more he heard; Why aren&#39;t we like that wise old bird?&#34;

--- a/html/lesson1/example.pt.html
+++ b/html/lesson1/example.pt.html
@@ -17,10 +17,10 @@
       <li><b>elas são adoráveis</b></li>
       <li><b>e amáveis</b></li>
       <li><b>e apertáveis</b></li>
+    </ol>
     <div><img src="images/img4.jpg"></div>
     <div><img src="images/img5.jpg"></div>
     <a href="https://www.youtube.com/watch?v=gBjnfgnwXic">Assista o vídeo</a>
-    </ol>
     <h4>
       <i>&#34;Uma coruja sábia e anciã pousou em um carvalho; Quanto mais observava, menos falava; <br>
          Quanto menos falava, mais ouvia; Por que não somos como a coruja sábia e anciã?


### PR DESCRIPTION
The tutorial says to place these `div`s after the `</ol>`, but the example placed them inside it, which isn't actually valid HTML.