### PR TITLE
fixed dead link

### DIFF
--- a/js/lesson3/tutorial.md
+++ b/js/lesson3/tutorial.md
@@ -46,8 +46,7 @@ Using jQuery and JavaScript functions, we are going to build a small
 todo list.
 
 Download the files that you will need to work through the example
-[here](download).
-<!-- https://gist.github.com/despo/309f684b7a6e002aaf1f/download -->
+[here](https://gist.github.com/309f684b7a6e002aaf1f/download)
 
 Alternatively, if you've already learned how to use git and would like
 to use it here, you can clone this repo:


### PR DESCRIPTION
Was there any reason why the link was commented out? The invalid download link has been confusing my students, so I would suggest either putting it back or, alternatively, removing the invitation to download and just asking students to clone the repo.