### PR TITLE
Fixed padding for content id so it isn't hidden by header.

### DIFF
--- a/html/lesson4/tutorial.md
+++ b/html/lesson4/tutorial.md
@@ -480,7 +480,7 @@ width: 100%;
 And reposition the `#content` so it doesn't hide underneath the header. Change the padding property to have a padding-top
 
 ```css
-padding: 160px 30px 40px;
+padding: 250px 30px 40px;
 ```
 
 > Do you remember the padding shortcuts we discussed in the previous lesson? What does the above describe? Can you explain that to your coach?


### PR DESCRIPTION
The content was hidden by the header when scrolling, I don't thing 160px is enough so increased to 250px.

Please discard if you're unable to reproduce, but confused me and my student.