### PR TITLE
Unify format & syntax across Python tutorial

### DIFF
--- a/python/lesson2/tutorial.md
+++ b/python/lesson2/tutorial.md
@@ -14,7 +14,7 @@ it a name then set its value.
 
 Now in the REPL type:
 
-	>>> year = 2016
+    >>> year = 2016
 
 In this example you have now stored the value `2016` into the variable `year`.
 See what happens next when you type `year' into the REPL. Does it show it back
@@ -30,9 +30,9 @@ variables with the maths operations we learnt in the previous tutorial.
 
 Now in the REPL type the following:
 
-	>>> revenue = 1000
-	>>> costs = 200
-	>>> profit = revenue - costs
+    >>> revenue = 1000
+    >>> costs = 200
+    >>> profit = revenue - costs
 
 Now type `profit` to see the results of this calculation. 
 
@@ -49,8 +49,8 @@ strings.
 
 Now in the REPL type:
 
-	>>> name = 'codebar'
-	>>> url = "codebar.io"
+    >>> name = 'codebar'
+    >>> url = "codebar.io"
 
 Now type `name` and `url` to see these strings shown back to you. As you can
 see Python allows both single and double quotes to denote a string variable.
@@ -58,13 +58,13 @@ Double quotes are required if there is going to be an apostrophe in the string.
 
 For example:
 
-	message = "I'm a string"
+    message = "I'm a string"
 
 Sometimes you will need to use an apostrophe within a single quote, on
 occasions like this it is recommended to use "string escaping". This would look
 like:
 
-	message ='I\'m a string'
+    message ='I\'m a string'
 
 Try storing a string within a variable without quotes, see what happens?
 Numbers do not require quotation marks, whereas they are mandatory for storing
@@ -122,20 +122,20 @@ command. Let's create a variable in which to store the user input.
 
 Now type this into your REPL: 
 
-	>>> lucky_number = input("What is your lucky number? ")
+    >>> lucky_number = input("What is your lucky number? ")
 
 Type back your answer after it asks you.
 
 Now in the REPL type:
 
-	>>> food = input("What is your favourite food? ")
+    >>> food = input("What is your favourite food? ")
 
 Now we are going to put your response into another variable.
 
 Now try:
 
-	>>> my_name = input("What is your name? ")
-	>>> greeting = "Hello " + my_name
+    >>> my_name = input("What is your name? ")
+    >>> greeting = "Hello " + my_name
 
 Then type `greeting` into your REPL to receive your message. 
 

--- a/python/lesson2/tutorial.md
+++ b/python/lesson2/tutorial.md
@@ -52,9 +52,10 @@ Now in the REPL type:
     >>> name = 'codebar'
     >>> url = "codebar.io"
 
-Now type `name` and `url` to see these strings shown back to you. As you can
-see Python allows both single and double quotes to denote a string variable.
-Double quotes are required if there is going to be an apostrophe in the string.
+Now type `print(name)` and `print(url)` to see these strings shown back to you.
+As you can see Python allows both single and double quotes to denote a string
+variable. Double quotes are required if there is going to be an apostrophe in
+the string.
 
 For example:
 
@@ -146,10 +147,10 @@ around with decision making and changing prints based on your answer. In Python
 (and many other languages), one of the most common ways in which this is done
 is using an `if` statement. For example:
 
-    if number > 3:
-        print("Bigger than three")
-	elif number < 3:
-        print("Smaller than three")
+    >>> if number > 3:
+    ...     print("Bigger than three")
+    ... elif number < 3:
+    ...     print("Smaller than three")
 
 Here we can see that if a number we have passed into this decision making code
 is bigger than three, we will receive a message telling us so. There is a

--- a/python/lesson3/tutorial.md
+++ b/python/lesson3/tutorial.md
@@ -39,18 +39,18 @@ which is where most people would expect things to start.  This means that the
 *first* element of a list is referred to with a `0`, the second element is
 referred to with a `1`, and so on.  Perhaps an example would be helpful:
 
-    >>> places_to_visit[0]
+    >>> print(places_to_visit[0])
     'Mexico'
-    >>> places_to_visit[2]
+    >>> print(places_to_visit[2])
     'Kenya'
 
 Positive numbers aren't the only thing you can use for indexes though. Negative
 numbers invert the index, so you can get the *last* element of a list by using
 `-1`, or the third-to-last by using `-3`:
 
-    >>> places_to_visit[-1]
+    >>> print(places_to_visit[-1])
     'New Zealand'
-    >>> places_to_visit[-3]
+    >>> print(places_to_visit[-3])
     'Kenya'
 
 Try it yourself now: Try to get `Nepal` out of `places_to_visit` using both a
@@ -71,23 +71,23 @@ There's a lot that you can do with lists, so much that we simply can't cover it
 all here, so instead here are some examples, and a [link to the documentation](https://docs.python.org/3.5/tutorial/datastructures.html#more-on-lists "Methods of lists")
 for a more complete reference:
 
-    >>> places_to_visit
+    >>> print(places_to_visit)
     ['Mexico', 'Portugal', 'Kenya', 'Nepal', 'New Zealand']
     
     >>> places_to_visit = ['Mexico', 'Portugal', 'Kenya', 'Nepal', 'New Zealand']
     >>> places_to_visit[1] = "Peru"
-    >>> places_to_visit
+    >>> print(places_to_visit)
     ['Mexico', 'Peru', 'Kenya', 'Nepal', 'New Zealand']
 
     >>> places_to_visit = ['Mexico', 'Portugal', 'Kenya', 'Nepal', 'New Zealand']
-    >>> places_to_visit.pop()
+    >>> print(places_to_visit.pop())
     'New Zealand'
-    >>> places_to_visit
+    >>> print(places_to_visit)
     ['Mexico', 'Portugal', 'Kenya', 'Nepal']
 
     >>> places_to_visit = ['Mexico', 'Portugal', 'Kenya', 'Nepal', 'New Zealand']
     >>> places_to_visit.append("Colombia")
-    >>> places_to_visit
+    >>> print(places_to_visit)
     ['Mexico', 'Portugal', 'Kenya', 'Nepal', 'New Zealand', 'Colombia']
 
 Try some of these out yourself:
@@ -103,22 +103,24 @@ But we're not finished!  You can do even more interesting things with `[` and
 to get the first four elements of a list *as another list*.  That's easy with
 the subset syntax:
 
-    >>> places_to_visit[0:4]
+    >>> print(places_to_visit[0:4])
     ["Mexico", "Portugal", "Kenya", "Nepal"]
-    >>> places_to_visit[:4]
+
+    >>> print(places_to_visit[:4])
     ["Mexico", "Portugal", "Kenya", "Nepal"]
 
 You can do some interesting things with negative numbers too:
 
-    >>> places_to_visit[-3:4]
+    >>> print(places_to_visit[-3:4])
     ['Kenya', 'Nepal']
-    >>> places_to_visit[-3:]
+
+    >>> print(places_to_visit[-3:])
     ['Kenya', 'Nepal', 'New Zealand']
 
 ...and as getting a subset returns a list itself, you can get a subset of a
 subset:
 
-    >>> places_to_visit[0:4][-1]
+    >>> print(places_to_visit[0:4][-1])
     'Nepal'
 
 ### Nesting
@@ -128,15 +130,15 @@ you from putting a list inside a list.  In fact, you can put a list inside a
 list, inside a list, inside a... you get the idea.  You're only limited by how
 many levels deep you can go before your code is too confusing:
 
-    cake_flavours = ["chocolate", ["chocolate", "vanilla"], "red velvet"]
+    >>> cake_flavours = ["chocolate", ["chocolate", "vanilla"], "red velvet"]
 
-    cake_flavours[0]
+    >>> print(cake_flavours[0])
     'chocolate'
 
-    cake_flavours[1]
+    >>> print(cake_flavours[1])
     ['chocolate', 'vanilla']
 
-    cake_flavours[1][1]
+    >>> print(cake_flavours[1][1])
     'vanilla'
 
 There's a lot more things you can do with lists including concatenating,
@@ -152,31 +154,31 @@ will result in a `TypeError`.
 
 Tuples are represented using `(` and `)`:
 
-    places_to_visit = ("Mexico", "Portugal", "Kenya", "Nepal", "New Zealand")
+    >>> places_to_visit = ("Mexico", "Portugal", "Kenya", "Nepal", "New Zealand")
 
-    places_to_visit[1]
+    >>> print(places_to_visit[1])
     'Portugal'
 
-    places_to_visit[0:3]
+    >>> print(places_to_visit[0:3])
     ('Mexico', 'Portugal', 'Kenya')
 
 This however will fail with a `TypeError`:
 
-    places_to_visit[1] = "Canada"
+    >>> places_to_visit[1] = "Canada"
 
 Tuples are commonly used in cases where you're defining something that
 shouldn't ever change, but should you ever need to modify something that's in a
 tuple, you can always *cast* it as a list:
 
-    my_tuple = (1, 2, 3)
+    >>> my_tuple = (1, 2, 3)
 
-    my_list = list(my_tuple)
-    my_list[2] = 99
+    >>> my_list = list(my_tuple)
+    >>> my_list[2] = 99
 
-    my_list
+    >>> print(my_list)
     [1, 2, 99]
 
-    my_tuple
+    >>> print(my_tuple)
     (1, 2, 3)
 
 This will make a **copy** of the tuple that's a list, so you can edit it, but
@@ -194,7 +196,7 @@ corresponding *values*.  You'll often seen them as a simple way to have a
 lookup table or crude database in an application.  For this tutorial we'll use
 a dictionary for a phone book:
 
-    my_phone_book = {
+    >>> my_phone_book = {
         "Arya": "+4407485376242",
         "Brienne": "+3206785246863",
         "Cersei": "+14357535455",
@@ -210,7 +212,7 @@ though.  This will give you Cersei's phone number:
 There's nothing restricting you to strings as values in your dictionary though.
 You can have *anything* in there:
 
-    my_crazy_dictionary = {
+    >>> my_crazy_dictionary = {
         "a number": 7,
         "a float": 1.23456789,
         "a string": "hello, world!",
@@ -228,7 +230,7 @@ can be used for keys, though this can sometimes lead to reduced readability,
 so use this with caution.  For example, while this is valid Python, it's not
 exactly easy to understand:
 
-    my_unreadable_dictionary = {
+    >>> my_unreadable_dictionary = {
         ("this", "is", "a", "tuple!"): {"a string": "hello, world!"}
     }
 
@@ -247,15 +249,15 @@ doing this should hopefully feel intuitive by now:
 
 Change a value for a key:
 
-    my_phone_book["Brienne"] = "+830685432195"
+    >>> my_phone_book["Brienne"] = "+830685432195"
 
 Add a new key/value pair:
 
-    my_phone_book["Ellaria"] = "+560538942621"
+    >>> my_phone_book["Ellaria"] = "+560538942621"
 
 This one is new: delete a key/value pair:
 
-    del(my_phone_book["Ellaria"])
+    >>> del(my_phone_book["Ellaria"])
 
 Now that you've got the tools to change your dictionaries, give a shot
 yourself.  Try changing Cersei's phone number.  In fact, change it to a list of
@@ -274,13 +276,13 @@ manageable parts.  Thankfully, Python has you covered with `.keys()`,
         "Cersei": "+14357535455",
         "Davos": "+244562726258"
     }
-    >>> my_phone_book.keys()
+    >>> print(my_phone_book.keys())
     dict_keys(['Davos', 'Cersei', 'Brienne', 'Arya'])
 
-    >>> my_phone_book.values()
+    >>> print(my_phone_book.values())
     dict_values(['+3206785246863', '+14357535455', '+244562726258', '+4407485376242'])
 
-    >>> my_phone_book.items()
+    >>> print(my_phone_book.items())
     dict_items([('Brienne', '+3206785246863'), ('Cersei', '+14357535455'), ('Davos', '+244562726258'), ('Arya', '+4407485376242')])
 
 As you can see, `.keys()` and `.values()` do what you'd expect: they return the
@@ -290,20 +292,20 @@ These are sort of like tuples: you can't edit them, and if you want to do
 anything with them other than read them as a complete entity, you'll have to
 cast them as a list:
 
-    >>> list(my_phone_book.keys())
+    >>> print(list(my_phone_book.keys()))
     ['+3206785246863', '+14357535455', '+244562726258', '+4407485376242']
 
-    >>> list(my_phone_book.keys())[2]
+    >>> print(list(my_phone_book.keys())[2])
     '+244562726258'
 
 The last one there, `.items()` is interesting.  It returns all of the data in
 your dictionary, but dumps it out as `dict_items` which is a sort of *tuple of
 tuples*.  This allows you to reference your dictionary with list syntax:
 
-    >>> tuple(my_phone_book.items())[0]
+    >>> print(tuple(my_phone_book.items())[0])
     ('Brienne', '+3206785246863')
 
-    >>> tuple(my_phone_book.items())[0][1]
+    >>> print(tuple(my_phone_book.items())[0][1])
     '+3206785246863'
 
 Truth be told though, you probably won't be accessing these values directly

--- a/python/lesson4/tutorial.md
+++ b/python/lesson4/tutorial.md
@@ -133,7 +133,7 @@ effort of defining and calling a function, rather than just writing the code
 independent of such things. Defining tasks as functions reduces the need to
 copy and paste the same code multiple times to achieve the same effect. Simply
 calling the function multiple times makes it much easier to not only write
-code, but to read it also.
+code, but to read it as well.
 
 Using functions also makes it a lot easier to fix and change code. If you are
 performing the same tasks in multiple places and discover a bug, without

--- a/python/lesson4/tutorial.md
+++ b/python/lesson4/tutorial.md
@@ -13,16 +13,16 @@ later to run these statements. Python comes with plenty of functions already
 built in that you can use to perform common tasks. One example should be
 something you're already familiar with:
 
-	>>> print("This is a function")
-	This is a function
-	
+    >>> print("This is a function")
+    This is a function
+    
 It is also possible to store the output of a function in a variable for future
 use. Let's try this with the built in function `len()`, which will provide us
 with the length of a string:
 
-	>>> length_of_my_string = len("This is my string")
-	>>> print(length_of_my_string)
-	17
+    >>> length_of_my_string = len("This is my string")
+    >>> print(length_of_my_string)
+    17
 
 The function `len()` takes one *argument*: the string it's measuring, and it
 returns an *integer*: the length of the string.  Here, we're storing the output


### PR DESCRIPTION
There were a number of inconsistencies in how the tutorial presents code, most commonly with using `>>> ` *sometimes* and regularly just typing out the variable name to mean "let the REPL tell you what this means" rather than using `print(variable_name)`.  This PR fixes both of those, along with some general clean up.