### PR TITLE
Fix dictionary ordering issues

### DIFF
--- a/python/lesson3/tutorial.md
+++ b/python/lesson3/tutorial.md
@@ -285,6 +285,13 @@ manageable parts.  Thankfully, Python has you covered with `.keys()`,
     >>> print(my_phone_book.items())
     dict_items([('Arya', '+4407485376242'), ('Brienne', '+3206785246863'), ('Cersei', '+14357535455'), ('Davos', '+244562726258')])
 
+> **Important**: dictionaries are *unordered*, which means that while it may
+> seem reasonable that you've defined `my_phone_book` above with the keys
+> ordered alphabetically, *that's not now how Python stores them*, so the
+> results above may differ in order from your output.  Typically if you need
+> your dictionary to be ordered, you'll use a list of lists, or an
+> `OrderedDict` (a topic for another day). 
+
 As you can see, `.keys()` and `.values()` do what you'd expect: they return the
 keys and values respectively.  You may have noticed however that rather than a
 `list` or a `tuple`, these methods return `dict_keys` and `dict_values` types.

--- a/python/lesson3/tutorial.md
+++ b/python/lesson3/tutorial.md
@@ -277,13 +277,13 @@ manageable parts.  Thankfully, Python has you covered with `.keys()`,
         "Davos": "+244562726258"
     }
     >>> print(my_phone_book.keys())
-    dict_keys(['Davos', 'Cersei', 'Brienne', 'Arya'])
+    dict_keys(['Arya', 'Brienne', 'Cersei', 'Davos'])
 
     >>> print(my_phone_book.values())
-    dict_values(['+3206785246863', '+14357535455', '+244562726258', '+4407485376242'])
+    dict_values(['+4407485376242', '+3206785246863', '+14357535455', '+244562726258'])
 
     >>> print(my_phone_book.items())
-    dict_items([('Brienne', '+3206785246863'), ('Cersei', '+14357535455'), ('Davos', '+244562726258'), ('Arya', '+4407485376242')])
+    dict_items([('Arya', '+4407485376242'), ('Brienne', '+3206785246863'), ('Cersei', '+14357535455'), ('Davos', '+244562726258')])
 
 As you can see, `.keys()` and `.values()` do what you'd expect: they return the
 keys and values respectively.  You may have noticed however that rather than a
@@ -293,19 +293,19 @@ anything with them other than read them as a complete entity, you'll have to
 cast them as a list:
 
     >>> print(list(my_phone_book.values()))
-    ['+3206785246863', '+14357535455', '+244562726258', '+4407485376242']
+    ['+4407485376242', '+3206785246863', '+14357535455', '+244562726258']
 
-    >>> print(list(my_phone_book.values())[2])
+    >>> print(list(my_phone_book.values())[3])
     '+244562726258'
 
 The last one there, `.items()` is interesting.  It returns all of the data in
 your dictionary, but dumps it out as `dict_items` which is a sort of *tuple of
 tuples*.  This allows you to reference your dictionary with list syntax:
 
-    >>> print(tuple(my_phone_book.items())[0])
+    >>> print(tuple(my_phone_book.items())[1])
     ('Brienne', '+3206785246863')
 
-    >>> print(tuple(my_phone_book.items())[0][1])
+    >>> print(tuple(my_phone_book.items())[1][1])
     '+3206785246863'
 
 Truth be told though, you probably won't be accessing these values directly


### PR DESCRIPTION
Rahel noticed another issue with the tutorial, so here's a "fix" for it.  The problem is really in how Python doesn't necessarily return the list in the expected order, so the code changes are mostly to account for the most likely outcome.  I've also added an explainer about ordering.