### PR TITLE
updated link to gist; previous link had buggy code

### DIFF
--- a/js/lesson2/tutorial.md
+++ b/js/lesson2/tutorial.md
@@ -7,7 +7,8 @@ In our previous lesson we learnt all about JavaScript variables, functions and o
 
 ## Before we start...
 
-Download the files required to begin working through the tutorial from [here](https://gist.github.com/despo/d46495ce986d1624af45/download).
+Download the files required to begin working through the tutorial from [here](https://gist.github.com/AniaMakes/d6b0edd5c7ca6ddbe9831616c766df84/download).
+
 
 In the first half of this tutorial we will be using the files **lesson2.html** and **script.js**, then files **london.html** and **london-script.js** for the second part.
 


### PR DESCRIPTION
The code that was linked previously 
a) was missing closing tag for <body>
b) had script in head, and script was fetching info from DOM - given that when script is run, relevant bits of DOM do not yet exist, this makes it the tutorial impossible to follow. 
I was hoping to make a pull request to gist, but that doesn't appear to be an option, so I forked, edited, and put the link to my gist on the tutorial. Please download and make sure it works before approving :)