### PR TITLE
fix Random#rand lower boundary explanation

### DIFF
--- a/ruby/lesson2/tutorial.md
+++ b/ruby/lesson2/tutorial.md
@@ -49,7 +49,7 @@ To get all the numbers from 1 up to 5, excluding 5.
 
 ### `Random.rand()`
 
-Random is an interface to a number generator. The `rand()` method takes in an integer value **max**. It returns an integer greater than zero and less than **max**. You can also use a **range** as a parameter.
+Random is an interface to a number generator. The `rand()` method takes in an integer value **max**. It returns an integer greater or equal than zero and less than **max**. You can also use a **range** as a parameter.
 
 ```ruby
 Random.rand(5..10)

--- a/ruby/lesson2/tutorial.md
+++ b/ruby/lesson2/tutorial.md
@@ -49,7 +49,7 @@ To get all the numbers from 1 up to 5, excluding 5.
 
 ### `Random.rand()`
 
-Random is an interface to a number generator. The `rand()` method takes in an integer value **max**. It returns an integer greater or equal than zero and less than **max**. You can also use a **range** as a parameter.
+Random is an interface to a number generator. The `rand()` method takes in an integer value **max**. It returns an integer greater than or equal to zero and less than **max**. You can also use a **range** as a parameter.
 
 ```ruby
 Random.rand(5..10)


### PR DESCRIPTION
I was working on this with a student today (first time at codebar :tada:) and we stumbled on this together when the `#rand` method returned `0` to our surprise. [ruby-doc.org](https://ruby-doc.org) says:

>[When max is an Integer, rand returns a random integer greater than or equal to zero and less than max.](https://ruby-doc.org/core-2.2.0/Random.html#method-i-rand)

This PR adds the words "or equal to" the `Random#rand` explanation.