### PR TITLE
Remove bonus section in Ruby Lesson 2, Exercise 1

### DIFF
--- a/ruby/lesson2/tutorial.md
+++ b/ruby/lesson2/tutorial.md
@@ -130,22 +130,6 @@ puts "Total time #{duration} seconds"
 puts "#{duration/turns} seconds per problem"
 ```
 
-### Bonus
-
-At the beginning of the game ask for the number of turns. If return is pressed default to 0.
-
-> To default value of a variable, only if the variable empty you can use the `||=` operant. This is called lazy loading.
-
-```ruby
-# here the number will get assigned to 1 as its value is nil
-number = nil
-number ||= 1
-
-# The number will not get assigned to 1 because it already has a value
-number = 2
-number ||= 1
-```
-
 ## Reading and writing to a file
 
 In Ruby we can use the `File` object to read and write to files.


### PR DESCRIPTION
I was working on this lesson with a student today and this bonus section doesn't seem to make a lot of sense to me.

The section explains that you can use the `||=` operator to set a value to a variable only if it's value is `nil`. The issue is that the student is most likely to do something like this:

```rb
number_of_turns = gets.to_i
```

which can never be `nil` since if you just hit <kbd>Enter</kbd> it will result in `number_of_turns` being set to 0.

Even if the student did something like:

```rb
number_of_turns = gets
```

with the intention of converting it to a integer later it would still not be enough to use the `||=` operator since `number_of_turns` will be set to a empty string when the user hits <kbd>Enter</kbd> at the turns prompt.

This PR removes the section completely rather then trying to rewrite it. If we really want to keep it around we could talk about the `NaN` results and error that is raised when a user hits <kbd>Enter</kbd> on the turns prompt and suggestions on how to fix it.