### PR TITLE
HTML tutorial 5 has an incorrect instruction re background images

### DIFF
--- a/html/lesson5/tutorial.md
+++ b/html/lesson5/tutorial.md
@@ -234,8 +234,8 @@ You can also set different properties for your backgrounds, by defining them in 
 First let's set two background images, the first positioned on the right and the second on the left.
 
 ```
-background: url('assets/images/background-right.jpg') right top no-repeat,
-            url('assets/images/background-left.jpg') left no-repeat;
+background: url('background-right.jpg') right top no-repeat,
+            url('background-left.jpg') left no-repeat;
 ```
 
 By default, a background image repeats itself to fill in the container. We don't want that, that's where the **no-repeat** property we specified comes into place.

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     <div class="wrapper">
 
       <header>
-        <h1>codebar tutorials</h1>
+        <h1>codebar tutorials..</h1>
         <img src="assets/codebar_logo.png" class="logo" alt="codebar logo">
         <p class="view"><a href="https://github.com/codebar/tutorials">View our tutorials on GitHub</a></p>
       </header>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     <div class="wrapper">
 
       <header>
-        <h1>codebar tutorials..</h1>
+        <h1>codebar tutorials</h1>
         <img src="assets/codebar_logo.png" class="logo" alt="codebar logo">
         <p class="view"><a href="https://github.com/codebar/tutorials">View our tutorials on GitHub</a></p>
       </header>


### PR DESCRIPTION
 I noticed with a student the other day that HTML tutorial 5 says the following:

```
First let’s set two background images, the first positioned on the right and the second on the left.
background: url('assets/images/background-right.jpg') right top no-repeat,
url('assets/images/background-left.jpg') left no-repeat;
```

This doesn't correspond with the directory structure of the example files, so the student initially got quite confused. Updated so the match.