### PR TITLE
Make "Getting started" link absolute

### DIFF
--- a/python/lesson1/tutorial.md
+++ b/python/lesson1/tutorial.md
@@ -128,7 +128,7 @@ multiple things at once, separated by a comma:
 
 In this tutorial you coded in the REPL (IDLE), but a lot of times you want
 to save your code instead. In such cases you can save your code to a file using a text editor. 
-We give some information on text editors in our [Getting started guide](general/setup/tutorial.html) .
+We give some information on text editors in our [Getting started guide](/general/setup/tutorial.html) .
 
 Open your text editor and write the code from the first exercise:
 


### PR DESCRIPTION
I tried clicking this link on the live site ( http://tutorials.codebar.io/python/lesson1/tutorial.html ) and it took me to a 404 page at http://tutorials.codebar.io/python/lesson1/general/setup/tutorial.html

This is because the page was using a relative link. This change makes it use an absolute link instead, which (when published) will go to http://tutorials.codebar.io/general/setup/tutorial.html (the correct page)