### PR TITLE
Switch python.org link from Python 2 to Python 3

### DIFF
--- a/python/lesson1/tutorial.md
+++ b/python/lesson1/tutorial.md
@@ -157,5 +157,5 @@ from the user, and make decisions based on that information.
 There is a very good introductory article in [Google Developers Guide](https://developers.google.com/edu/python/introduction).
 
 You can also find resources for beginners on [the Python website](https://www.python.org/about/gettingstarted/)
-and refer to [the Python documentation](https://docs.python.org/2/tutorial/introduction.html),
+and refer to [the Python documentation](https://docs.python.org/3/tutorial/introduction.html),
 where the language basics are explained.


### PR DESCRIPTION
The codebar documentation seems to focus on Python3, so it should presumably link to the Python3 tutorial rather than the Python2 one.