### PR TITLE
(JS lesson 2) Rename population var

### DIFF
--- a/js/lesson2/tutorial.md
+++ b/js/lesson2/tutorial.md
@@ -552,16 +552,16 @@ var london = {
 ```js
 function displayPopulation() {
   // Make a new <p></p> for population. This is not attached to the DOM yet.
-  var population = document.createElement('p');
+  var paragraph = document.createElement('p');
 
   // Make some text content to put into your <p></p>
   var content = document.createTextNode('Population: ' + london.population);
 
   // Put the text content into the <p></p>.
-  population.appendChild(content);
+  paragraph.appendChild(content);
 
   // Finally the population can be appended to the body, and will become visible in the browser.
-  document.body.appendChild(population);
+  document.body.appendChild(paragraph);
 }
 ```
 


### PR DESCRIPTION
Hey,

I was helping someone with this lesson, and they found it confusing when creating the `displayPopulation` function, as the first variable was named the same as the object key they needed to reference.

```js
var london = {
  name: 'London',
  population: 8308369,
  // ...
}
```

```js
function displayPopulation() {
  var population = document.createElement('p');
  // ...
}
```

I've changed the variable name from "population", to "paragraph". 

This helps the next line read nicer too; "append content to paragraph", rather than "append content to population"

```js
paragraph.appendChild(content);
```