### PR TITLE
Add donate box in footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,6 +132,14 @@
 
       </section>
     </div>
+
+    <footer>
+      <div class="donation-box">
+        <p>Looking for a way to support codebar? Please consider making a donation</p>
+        <a href="https://codebar.enthuse.com/donate/#!/">Donate</a>
+      </div>
+      <p class="small">Registered UK and Wales charity no. 1187776 © codebar 2021</p>
+    </footer>
     <script src="javascripts/scale.fix.js"></script>
     <script type="text/javascript">
       var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -56,6 +56,8 @@ a small {
 .wrapper {
   width: 860px;
   margin: 0 auto;
+  display: flex;
+  justify-content: space-between;
 }
 
 .logo {
@@ -110,8 +112,6 @@ img {
 
 header {
   width: 270px;
-  float: left;
-  position: fixed;
 }
 
 header ul {
@@ -174,7 +174,6 @@ header ul a strong {
 
 section {
   width: 500px;
-  float: right;
   padding-bottom: 50px;
 }
 
@@ -190,10 +189,30 @@ hr {
 }
 
 footer {
-  width: 270px;
-  float: left;
-  position: fixed;
-  bottom: 50px;
+  max-width: 860px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+}
+
+.donation-box {
+  border: 4px solid #4bafff;
+  padding: 65px 0;
+  margin-bottom: 50px;
+}
+
+.donation-box p {
+  font-size: 20px;
+}
+
+.donation-box a {
+  background-color: #4bafff;
+  color: #fff;
+  font-weight: bold;
+  font-size: 18px;
+  padding: 10px 13px;
+  border-radius: 5px;
 }
 
 @media print, screen and (max-width: 960px) {
@@ -201,23 +220,20 @@ footer {
   div.wrapper {
     width: auto;
     margin: 0;
-  }
-
-  header, section, footer {
-    float: none;
-    position: static;
-    width: auto;
+    flex-direction: column;
   }
 
   header {
-    padding-right: 320px;
+    width: 100%;
+    text-align: center;
+  }
+
+  section, footer {
+    width: auto;
   }
 
   section {
-    border: 1px solid #e5e5e5;
-    border-width: 1px 0;
     padding: 20px 0;
-    margin: 0 0 20px;
   }
 
   header a small {
@@ -247,6 +263,15 @@ footer {
   pre, code {
     word-wrap: normal;
   }
+
+  .donation-box {
+    padding: 50px 0;
+  }
+
+  .donation-box p {
+    font-size: 17px;
+  }
+
 }
 
 @media print, screen and (max-width: 480px) {


### PR DESCRIPTION
Added a donate box inside a footer on the main page, which now matches the stats website. Also, added a copyright text with our registered charity number. The screenshot below shows the new box on the main page.

Also removed some float:left/float:right code in favour of flex.

![screencapture-0-0-0-0-4000-2021-04-14-18_36_16](https://user-images.githubusercontent.com/2683270/114746969-38bc4200-9d48-11eb-9ee5-867ee19431a1.png)
